### PR TITLE
Set correct path to css

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -56,9 +56,9 @@ function theme_nhse_get_main_scss_content($theme) {
 //    $scss .= file_get_contents($CFG->dirroot . '/theme/boost/scss/moodle.scss');
 
     // Get main theme file and combine them together.
-    // $scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/css/nhse.min.css');
-    $scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/scss/nhsuk.scss');
-    $scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/scss/nhse.scss');
+    $scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/css/nhse.min.css');
+    //$scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/scss/nhsuk.scss');
+    //$scss .= "\n" . file_get_contents($CFG->dirroot . '/theme/nhse/scss/nhse.scss');
 
     return $scss;
 }


### PR DESCRIPTION
The path to the scss was not pointing to the minified css created from the npm run build and was causing the theme not to display correctly.