### PR TITLE
Add standard footer elements

### DIFF
--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -48,7 +48,8 @@
             <div class="nhsuk-u-float-right">
                 <p class="nhsuk-footer__copyright">© NHS England</p>
             </div>
-
+            {{{ output.standard_footer_html }}}
+            {{{ output.standard_end_of_body_html }}}
         </div>
     </div>
 </footer>


### PR DESCRIPTION
When editing the footer to add the Learning Pool footer elements, some essential elements were accidentally removed. The removal appears to prevent some links within Moodle working.