### PR TITLE
Remove unnecessary footer element

### DIFF
--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -48,7 +48,6 @@
             <div class="nhsuk-u-float-right">
                 <p class="nhsuk-footer__copyright">© NHS England</p>
             </div>
-            {{{ output.standard_footer_html }}}
             {{{ output.standard_end_of_body_html }}}
         </div>
     </div>


### PR DESCRIPTION
Removed some markup from the footer.mustache file that was displaying an element that is not needed as seen in this grab

![image](https://github.com/user-attachments/assets/5a787a65-3b7d-418b-a447-12684ba34029)
