### PR TITLE
Update footer links to full path

### DIFF
--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -38,12 +38,12 @@
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
             <ul class="nhsuk-footer__list">
                 <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://support.learninghub.nhs.uk/">Help</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Home/Contactus">Contact us</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Home/Aboutus">About us</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Updates">Service updates and releases</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Home/NHSsites">NHS sites</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Policies">Our policies</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="/Home/Accessibility">Accessibility statement</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Contactus">Contact us</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Aboutus">About us</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Updates">Service updates and releases</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/NHSsites">NHS sites</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Policies">Our policies</a></li>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Accessibility">Accessibility statement</a></li>
             </ul>
             <div class="nhsuk-u-float-right">
                 <p class="nhsuk-footer__copyright">© NHS England</p>


### PR DESCRIPTION
I have updated the hard coded links in the footer from using relative paths to using the full URL paths as when used within the Moodle theme, the relative paths do not work due to it being on a subdomain.