### PR TITLE
Update api call to use Moodle theme base URL

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -116,7 +116,12 @@ class core_renderer extends \theme_boost\output\core_renderer
             error_log("theme_nhse: User not logged in, skipping OIDC token fetch.");
         }
 
-         $url = 'https://lh-openapi.dev.local/User/GetLHUserNavigation';
+        // --- The rest of your existing API call logic ---
+        $api_endpoint_path = 'User/GetLHUserNavigation';
+        $url = $api_base_url . $api_endpoint_path;
+
+
+        
          try 
          {
             $curl = new \curl();


### PR DESCRIPTION
Fixed an issue where the path to the API was still using the hard coded local path. It now uses the prefix added in the theme settings.