### PR TITLE
Update logo link in header to point to main Learning Hub instance

### DIFF
--- a/templates/header.mustache
+++ b/templates/header.mustache
@@ -59,7 +59,7 @@
     <div class="nhsuk-width-container nhsuk-header__container app-width-container">
 
         <div class="nhsuk-header__logo">
-            <a class="nhsuk-header__link nhsuk-header__link--service" href="{{{ config.homeurl }}}" aria-label="{{{ sitename }}}">
+            <a class="nhsuk-header__link nhsuk-header__link--service" href="{{dotnet_base_url}}" aria-label="{{{ sitename }}}">
             <!--            {{# output.should_display_navbar_logo }}-->
             <!--            <img src="{{output.get_compact_logo_url}}" class="logo mr-1" alt="{{{ sitename }}}" height="50" style="padding: 5px 0;">-->
             <!--            {{/ output.should_display_navbar_logo }}-->


### PR DESCRIPTION
Updated the navbar logo link to use the theme dot net url path so it links back to the Learning Hub instance home page