### PR TITLE
Update footer links to use base url from theme settings

### DIFF
--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -36,15 +36,15 @@
         <div class="nhsuk-width-container footer-content-popover container" data-region="footer-content-popover">
             <div class="nhsuk-width-container">
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
-            <ul class="nhsuk-footer__list">
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://support.learninghub.nhs.uk/">Help</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Contactus">Contact us</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Aboutus">About us</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Updates">Service updates and releases</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/NHSsites">NHS sites</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Policies">Our policies</a></li>
-                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="https://learninghub.nhs.uk/Home/Accessibility">Accessibility statement</a></li>
-            </ul>
+                <ul class="nhsuk-footer__list">
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" target="_blank" href="https://support.learninghub.nhs.uk/support/home">Help</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Contactus">Contact us</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Aboutus">About us</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Updates">Service updates and releases</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/NHSsites">NHS sites</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Policies">Our policies</a></li>
+                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Accessibility">Accessibility statement</a></li>
+                </ul>
             <div class="nhsuk-u-float-right">
                 <p class="nhsuk-footer__copyright">© NHS England</p>
             </div>


### PR DESCRIPTION
I have updated the footer links to use the domain prefix set in the Moodle theme settings. 