### PR TITLE
Ensure SCORM content has background when full screen

### DIFF
--- a/javascript/scorm-fullscreen.js.php
+++ b/javascript/scorm-fullscreen.js.php
@@ -249,6 +249,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         scormIframe.style.setProperty('width', '100%', 'important');
                         scormIframe.style.setProperty('height', '100%', 'important');
                         scormIframe.style.setProperty('display', 'block', 'important'); // Ensure it's not hidden
+                        scormIframe.style.setProperty('background-color', '#ffffff', 'important'); 
                     }
 
                     // *** REMOVED: Hiding #page-wrapper as it hides everything! ***
@@ -300,6 +301,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     scormIframe.style.removeProperty('width');
                     scormIframe.style.removeProperty('height');
                     scormIframe.style.removeProperty('display');
+                    scormIframe.style.removeProperty('background-color');
                 }
 
                 // *** REMOVED: Restoring #page-wrapper is no longer needed if we don't hide it ***


### PR DESCRIPTION
There was an issue whereby when a type 6 SCORM session was viewed in Moodle, there was no background colour and the content was appearing with a black background. I have added a background-color property to the iFrame setting it to white when full screen. Possibly something that could have been resolved by updating type 6 code itself but this would not resolve any existing published type 6 sessions.

<img width="953" height="512" alt="image" src="https://github.com/user-attachments/assets/0feaf846-29ed-42f2-bdf6-36a809286989" />
