### PR TITLE
Fix alignment issue of breadcrumb and session title

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -397,6 +397,7 @@ body {
 @media (min-width: 768px) {
   .header-maxwidth {
     padding-left: 0;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Addition of CSS to prevent the area that includes the breadcrumb and session title from being constrained to a fixed width causing it to not be left aligned.

<img width="762" height="494" alt="image" src="https://github.com/user-attachments/assets/493f8ead-db00-4fef-821c-2677aa7a1cd9" />
