### PR TITLE
TD-5808 - hide activity icons

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1355,3 +1355,6 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
   display: none !important;
 }
 
+.activity-icon {
+  display: none;
+}


### PR DESCRIPTION
Simply hidden moodle activity items with display:none on activity-icon class

Before
<img width="1094" height="980" alt="image" src="https://github.com/user-attachments/assets/d295d6b6-1afa-49ba-b1bb-b1cc49a9229e" />

After
<img width="1098" height="978" alt="image" src="https://github.com/user-attachments/assets/0da486c0-3729-486a-a1cf-fcf69f0f0557" />
