### PR TITLE
add navigation theme files and styling

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1355,16 +1355,6 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
   display: none !important;
 }
 
-// // TD-5818
-// .section-navigation .nextsection a {
-//   display: inline-flex;
-//   flex-direction: row-reverse;
-// }
-
-// .section-navigation .jumpmenu {
-//   display: none;
-// }
-
 .nhsuk-pagination__link .nhsuk-icon {
   fill: #005eb8;
 }

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1342,12 +1342,12 @@ body.simulated-fullscreen #scormpage {
 
 /* Remove page-wrapper padding in simulated fullscreen */
 body.simulated-fullscreen #page-wrapper #page .main-inner {
-    padding: 0 !important;
+  padding: 0 !important;
 }
 
 /* Remove drawer padding in simulated fullscreen */
 body.simulated-fullscreen #page.drawers .main-inner {
-    padding: 0 !important;
+  padding: 0 !important;
 }
 
 /* Hide Moodle's default Exit activity button in simulated fullscreen */
@@ -1355,3 +1355,16 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
   display: none !important;
 }
 
+// // TD-5818
+// .section-navigation .nextsection a {
+//   display: inline-flex;
+//   flex-direction: row-reverse;
+// }
+
+// .section-navigation .jumpmenu {
+//   display: none;
+// }
+
+.nhsuk-pagination__link .nhsuk-icon {
+  fill: #005eb8;
+}

--- a/templates/core_courseformat/local/content/sectionnavigation.mustache
+++ b/templates/core_courseformat/local/content/sectionnavigation.mustache
@@ -1,0 +1,48 @@
+{{!
+    @template core_courseformat/local/content/sectionnavigation
+
+    Displays the course section navigation.
+
+    Example context (json):
+    {
+        "hasprevious": true,
+        "previousurl": "#",
+        "larrow": "&#x25C4;",
+        "previousname": "Section 3",
+        "hasnext": true,
+        "rarrow": "&#x25BA;",
+        "nexturl": "#",
+        "nextname": "Section 5"
+    }
+}}
+
+<nav class="section-navigation nhsuk-pagination" role="navigation" aria-label="Pagination">
+  <ul class="nhsuk-list nhsuk-pagination__list">
+    {{#hasprevious}}  
+    <li class="nhsuk-pagination-item--previous">
+      <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{{previousurl}}}">
+        <span class="nhsuk-pagination__title">Previous</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
+        <span class="nhsuk-pagination__page">{{{previousname}}}</span>
+        <svg class="nhsuk-icon nhsuk-icon--arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+          <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
+        </svg>
+
+      </a>
+    </li>
+    {{/hasprevious}}
+    {{#hasnext}}    
+    <li class="nhsuk-pagination-item--next">
+      <a class="nhsuk-pagination__link nhsuk-pagination__link--next" href="{{{nexturl}}}">
+        <span class="nhsuk-pagination__title">Next</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
+        <span class="nhsuk-pagination__page">{{{nextname}}}</span>
+        <svg class="nhsuk-icon nhsuk-icon--arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+          <path d="m14.7 6.3 5 5c.2.2.3.4.3.7 0 .3-.1.5-.3.7l-5 5a1 1 0 0 1-1.4-1.4l3.3-3.3H5a1 1 0 0 1 0-2h11.6l-3.3-3.3a1 1 0 1 1 1.4-1.4Z"></path>
+        </svg>
+
+      </a>
+    </li>
+    {{/hasnext}}    
+  </ul>
+</nav>

--- a/templates/core_courseformat/local/content/sectionnavigation.mustache
+++ b/templates/core_courseformat/local/content/sectionnavigation.mustache
@@ -1,21 +1,3 @@
-{{!
-    @template core_courseformat/local/content/sectionnavigation
-
-    Displays the course section navigation.
-
-    Example context (json):
-    {
-        "hasprevious": true,
-        "previousurl": "#",
-        "larrow": "&#x25C4;",
-        "previousname": "Section 3",
-        "hasnext": true,
-        "rarrow": "&#x25BA;",
-        "nexturl": "#",
-        "nextname": "Section 5"
-    }
-}}
-
 <nav class="section-navigation nhsuk-pagination" role="navigation" aria-label="Pagination">
   <ul class="nhsuk-list nhsuk-pagination__list">
     {{#hasprevious}}  

--- a/templates/core_courseformat/local/content/sectionselector.mustache
+++ b/templates/core_courseformat/local/content/sectionselector.mustache
@@ -1,0 +1,49 @@
+{{!
+    @template core_courseformat/local/content/sectionselector
+
+    Displays the course section navigation.
+
+    Example context (json):
+    {
+        "hasprevious": true,
+        "previousurl": "#",
+        "larrow": "&#x25C4;",
+        "previousname": "Section 3",
+        "hasnext": true,
+        "rarrow": "&#x25BA;",
+        "nexturl": "#",
+        "nextname": "Section 5",
+        "selector": "<select><option>Section 4</option></select>"
+    }
+}}
+
+<nav class="section-navigation nhsuk-pagination" role="navigation" aria-label="Pagination">
+  <ul class="nhsuk-list nhsuk-pagination__list">
+    {{#hasprevious}}
+    <li class="nhsuk-pagination-item--previous">
+      <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="{{{previousurl}}}">
+        <span class="nhsuk-pagination__title">Previous</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
+        <span class="nhsuk-pagination__page">{{{previousname}}}</span>
+        <svg class="nhsuk-icon nhsuk-icon--arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+          <path d="M10.7 6.3c.4.4.4 1 0 1.4L7.4 11H19a1 1 0 0 1 0 2H7.4l3.3 3.3c.4.4.4 1 0 1.4a1 1 0 0 1-1.4 0l-5-5A1 1 0 0 1 4 12c0-.3.1-.5.3-.7l5-5a1 1 0 0 1 1.4 0Z"></path>
+        </svg>
+
+      </a>
+    </li>
+    {{/hasprevious}}
+    {{#hasnext}}
+    <li class="nhsuk-pagination-item--next">
+      <a class="nhsuk-pagination__link nhsuk-pagination__link--next" href="{{{nexturl}}}">
+        <span class="nhsuk-pagination__title">Next</span>
+        <span class="nhsuk-u-visually-hidden">:</span>
+        <span class="nhsuk-pagination__page">{{{nextname}}}</span>
+        <svg class="nhsuk-icon nhsuk-icon--arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+          <path d="m14.7 6.3 5 5c.2.2.3.4.3.7 0 .3-.1.5-.3.7l-5 5a1 1 0 0 1-1.4-1.4l3.3-3.3H5a1 1 0 0 1 0-2h11.6l-3.3-3.3a1 1 0 1 1 1.4-1.4Z"></path>
+        </svg>
+
+      </a>
+    </li>
+    {{/hasnext}}
+  </ul>
+</nav>

--- a/templates/core_courseformat/local/content/sectionselector.mustache
+++ b/templates/core_courseformat/local/content/sectionselector.mustache
@@ -1,22 +1,3 @@
-{{!
-    @template core_courseformat/local/content/sectionselector
-
-    Displays the course section navigation.
-
-    Example context (json):
-    {
-        "hasprevious": true,
-        "previousurl": "#",
-        "larrow": "&#x25C4;",
-        "previousname": "Section 3",
-        "hasnext": true,
-        "rarrow": "&#x25BA;",
-        "nexturl": "#",
-        "nextname": "Section 5",
-        "selector": "<select><option>Section 4</option></select>"
-    }
-}}
-
 <nav class="section-navigation nhsuk-pagination" role="navigation" aria-label="Pagination">
   <ul class="nhsuk-list nhsuk-pagination__list">
     {{#hasprevious}}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2025031101;
+$plugin->version = 2025091201;
 $plugin->release = '404.4.0';
 $plugin->maturity = MATURITY_BETA;
 


### PR DESCRIPTION
Added mustache files to theme directory to override old next/prev styling
New version uses NHSE next/prev code
Updated css to force blue link colour to unvisited links

<img width="465" height="888" alt="image" src="https://github.com/user-attachments/assets/b50ff95f-63ab-4e39-af94-5fd3388b36a3" /> 
<img width="492" height="900" alt="image" src="https://github.com/user-attachments/assets/1648c131-1312-458e-acd0-68baaadf15e9" /> 
<img width="1258" height="729" alt="image" src="https://github.com/user-attachments/assets/c2510bfc-93e2-4910-87a4-026ef0faf295" />


