### PR TITLE
Add and hook up Admin URL theme property

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -182,10 +182,19 @@ class core_renderer extends \theme_boost\output\core_renderer
                     $processed_item->title = $item['title'] ?? 'Untitled'; // Default title if missing
                     // Handle URLs - convert to moodle_url if internal, keep as string if external
                     if (isset($item['url']) && !empty($item['url'])) {
-                        $item_url_path = $item['url']; // Store the raw URL from the API
-
+                        $item_url_path = $item['url']; // Store the raw URL from the API       
+                        // --- NEW: Override URL for 'Admin' link with theme setting ---
+                        if (trim($processed_item->title) === 'Admin') {
+                            $admin_url = get_config('theme_nhse', 'admin_url');
+                            if (!empty($admin_url)) {
+                                $processed_item->url = $admin_url;
+                                error_log("theme_nhse: Overriding 'Admin' URL with theme setting: {$processed_item->url}");
+                            } else {
+                                // Fallback to original logic if theme setting is not configured
+                                error_log("theme_nhse: Admin URL theme setting not found, falling back to API URL.");
+                            }
                         // Check if it's an absolute URL (starts with http/s or //)
-                        if (strpos($item_url_path, 'http') === 0 || strpos($item_url_path, '//') === 0) {
+                        } else if (strpos($item_url_path, 'http') === 0 || strpos($item_url_path, '//') === 0) {
                             $processed_item->url = $item_url_path; // Use the absolute URL as is
                             error_log("theme_nhse: Processing absolute URL: {$processed_item->url}");
                         } 

--- a/settings.php
+++ b/settings.php
@@ -26,7 +26,7 @@ if ($ADMIN->fulltree) {
     $settings = new theme_boost_admin_settingspage_tabs('themesettingnhse', get_string('configtitle', 'theme_nhse'));
     $page = new admin_settingpage('theme_nhse_general', get_string('generalsettings', 'theme_nhse'));
 
-     // --- NEW: Add the .NET Application Base URL setting to the 'General' tab ---
+     // Theme customisable property: Add the .NET Application Base URL setting to the 'General' tab ---
     $page->add(new admin_setting_configtext(
         'theme_nhse/dotnet_base_url', // Unique identifier for this setting
         get_string('dotnet_base_url_setting', 'theme_nhse'), // Display title
@@ -35,7 +35,7 @@ if ($ADMIN->fulltree) {
         PARAM_URL // Moodle will validate the input as a URL
     ));
 
-     // --- NEW: Add the API Base URL setting ---
+     // Theme customisable property: Add the API Base URL setting ---
     $page->add(new admin_setting_configtext(
         'theme_nhse/api_base_url', // Unique identifier for this setting
         get_string('api_base_url_setting', 'theme_nhse'), // Display title
@@ -43,6 +43,16 @@ if ($ADMIN->fulltree) {
         '', // Default value (empty string)
         PARAM_URL // Moodle will validate this as a URL
     ));
+
+         // Theme customisable property: Add the Admin URL setting ---
+    $page->add(new admin_setting_configtext(
+        'theme_nhse/admin_url', // Unique identifier for this setting
+        get_string('admin_url_setting', 'theme_nhse'), // Display title
+        get_string('admin_url_setting_desc', 'theme_nhse'), // Description
+        '', // Default value (empty string)
+        PARAM_URL // Moodle will validate this as a URL
+    ));
+
 
     // Unaddable blocks.
     // Blocks to be excluded when this theme is enabled in the "Add a block" list: Administration, Navigation, Courses and


### PR DESCRIPTION
This update adds a new theme property to hard code the Admin URL for the Admin link that appears on the navigation bar.

The open api is unable to return the correct URL for this hence the need to hard code it.

This is the same link that the Admin button when logged into the Learning Hub will have.

To edit this theme property, open Themes in Moodle Site Administration and select the settings cog for the NHSE theme