### PR TITLE
Update course section expander to nhsuk version

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1381,12 +1381,14 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 }
 
 .nhsuk-details.nhsuk-expander .section_link,
+.nhsuk-details.nhsuk-expander .summarytext,
 .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
   padding-left: 0.75rem;
 }
 
 @media (max-width: 37.49em) {
   .nhsuk-details.nhsuk-expander .section_link,
+  .nhsuk-details.nhsuk-expander .summarytext,
   .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
     padding-left: 0.5rem;
   }

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1368,3 +1368,26 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 .nhsuk-pagination__link .nhsuk-icon {
   fill: #005eb8;
 }
+
+.course-section .section-item {
+  padding: 0px;
+  border: none;
+  border-radius: 0px;
+}
+
+.nhsuk-expander .h4.sectionname {
+  font-size: 1.1875rem;
+  font-weight: 400;
+}
+
+.nhsuk-details.nhsuk-expander .section_link,
+.course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
+  padding-left: 0.75rem;
+}
+
+@media (max-width: 37.49em) {
+  .nhsuk-details.nhsuk-expander .section_link,
+  .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
+    padding-left: 0.5rem;
+  }
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1394,6 +1394,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
   }
 }
 
-.nhsuk-expander .nhsuk-details__summary:focus .nhsuk-details__summary-text:before {
+.section-item .nhsuk-expander .nhsuk-details__summary:focus .nhsuk-details__summary-text:before,
+.section-item .nhsuk-expander[open] .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
   background-color: transparent;
 }

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1393,3 +1393,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
     padding-left: 0.5rem;
   }
 }
+
+.nhsuk-expander .nhsuk-details__summary:focus .nhsuk-details__summary-text:before {
+  background-color: transparent;
+}

--- a/templates/core_courseformat/local/content/section/content.mustache
+++ b/templates/core_courseformat/local/content/section/content.mustache
@@ -1,0 +1,249 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core_courseformat/local/content/section/content
+
+    The internal content of a section.
+
+    Example context (json):
+    {
+        "num": 3,
+        "id": 35,
+        "controlmenu": "[tools menu]",
+        "header": {
+            "name": "Section title",
+            "title": "<a href=\"http://moodle/course/view.php?id=5#section-0\">Section title</a>",
+            "url": "#",
+            "ishidden": true,
+            "headinglevel": 3
+        },
+        "cmlist": {
+            "cms": [
+                {
+                    "cmitem": {
+                        "cmformat": {
+                            "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
+                            "hasname": "true"
+                        },
+                        "id": 3,
+                        "cmid": 3,
+                        "module": "forum",
+                        "anchor": "activity-3",
+                        "extraclasses": "newmessages"
+                    }
+                },
+                {
+                    "cmitem": {
+                        "cmformat": {
+                            "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Assign example</span></a>",
+                            "hasname": "true"
+                        },
+                        "id": 4,
+                        "cmid": 4,
+                        "anchor": "activity-4",
+                        "module": "assign",
+                        "extraclasses": ""
+                    }
+                }
+            ],
+            "hascms": true
+        },
+        "ishidden": false,
+        "iscurrent": true,
+        "currentlink": "<span class=\"accesshide\">This topic</span>",
+        "availability": {
+            "info": "<span class=\"badge bg-info\">Hidden from students</span>",
+            "hasavailability": true
+        },
+        "summary": {
+            "summarytext": "Summary text!"
+        },
+        "controlmenu": {
+            "menu": "<a href=\"#\" class=\"d-inline-block dropdown-toggle icon-no-margin\">Edit<b class=\"caret\"></b></a>",
+            "hasmenu": true
+        },
+        "cmcontrols": "[Add an activity or resource]",
+        "iscoursedisplaymultipage": true,
+        "sectionreturnnum": 0,
+        "contentcollapsed": false,
+        "insertafter": true,
+        "numsections": 42,
+        "sitehome": false,
+        "isstealth": false,
+        "highlightedlabel" : "Highlighted"
+    }
+}}
+{{^displayonesection}}
+    <details class="nhsuk-details nhsuk-expander"
+        data-for="section_title"
+        data-id="{{id}}"
+        data-number="{{num}}"
+    >
+        <summary class="nhsuk-details__summary">
+            <span class="nhsuk-details__summary-text">
+                {{#singleheader}}
+                    {{$ core_courseformat/local/content/section/header }}
+                        {{> core_courseformat/local/content/section/header }}
+                    {{/ core_courseformat/local/content/section/header }}
+                {{/singleheader}}
+                {{#header}}
+                    {{$ core_courseformat/local/content/section/header }}
+                        {{> core_courseformat/local/content/section/header }}
+                    {{/ core_courseformat/local/content/section/header }}
+                {{/header}}
+                {{^singleheader}}
+                    {{#restrictionlock}}
+                        <div class="align-self-center ms-2">
+                            {{#pix}}t/unlock, core{{/pix}}
+                        </div>
+                    {{/restrictionlock}}
+                {{/singleheader}}
+                <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
+                    {{$ core_courseformat/local/content/section/badges }}
+                        {{> core_courseformat/local/content/section/badges }}
+                    {{/ core_courseformat/local/content/section/badges }}
+                </div>
+                {{#controlmenu}}
+                    {{^displayonesection}}
+                        {{$ core_courseformat/local/content/section/controlmenu }}
+                            {{> core_courseformat/local/content/section/controlmenu }}
+                        {{/ core_courseformat/local/content/section/controlmenu }}
+                    {{/displayonesection}}
+                {{/controlmenu}}
+                {{#header}}
+                    {{#headerdisplaymultipage}}
+                        {{^displayonesection}}
+                            {{^controlmenu}}
+                                <div class="section_goto bulk-hidden ms-auto" data-sectionid="{{id}}">
+                                    <a href="{{{url}}}"
+                                    class="btn btn-icon d-flex align-items-center justify-content-center icon-no-margin"
+                                    title="{{#str}}gotosection, course, {{name}}{{/str}}">
+                                        <span class="dir-rtl-hide">
+                                            {{#pix}}t/right, moodle{{/pix}}
+                                        </span>
+                                        <span class="dir-ltr-hide">
+                                            {{#pix}}t/left, moodle, {{#str}}gotosection, course, {{name}}{{/str}}{{/pix}}
+                                        </span>
+                                        <span class="sr-only">
+                                            {{#str}}gotosection, course, {{name}}{{/str}}
+                                        </span>
+                                    </a>
+                                </div>
+                            {{/controlmenu}}
+                        {{/displayonesection}}
+                    {{/headerdisplaymultipage}}
+                {{/header}}
+            </span>
+        </summary>
+
+        <div class="nhsuk-details__text content">
+            <div class="section_link">
+                <a href="{{{header.url}}}">Go to {{{header.name}}}</a>
+            </div>
+            <div class="{{#hasavailability}}description{{/hasavailability}} my-3" data-for="sectioninfo">
+                {{#isstealth}}
+                <div class="alert alert-warning">
+                    {{#str}} orphansectionwarning, core_courseformat {{/str}}
+                </div>
+                {{/isstealth}}
+                {{#summary}}
+                    {{$ core_courseformat/local/content/section/summary }}
+                        {{> core_courseformat/local/content/section/summary }}
+                    {{/ core_courseformat/local/content/section/summary }}
+                {{/summary}}
+                {{#availability}}
+                    {{$ core_courseformat/local/content/section/availability }}
+                        {{> core_courseformat/local/content/section/availability }}
+                    {{/ core_courseformat/local/content/section/availability }}
+                {{/availability}}
+            </div>
+            {{#cmsummary}}
+            <!-- cmsummary -->
+                {{$ core_courseformat/local/content/section/cmsummary }}
+                    {{> core_courseformat/local/content/section/cmsummary }}
+                {{/ core_courseformat/local/content/section/cmsummary }}
+            {{/cmsummary}}
+            {{#cmlist}}
+            <!-- cmlist -->
+                {{$ core_courseformat/local/content/section/cmlist }}
+                    {{> core_courseformat/local/content/section/cmlist }}
+                {{/ core_courseformat/local/content/section/cmlist }}
+            {{/cmlist}}
+            {{{cmcontrols}}}
+        </div>
+    </details>
+{{/displayonesection}}
+
+{{#displayonesection}}
+    <div
+        data-for="section_title"
+        data-id="{{id}}"
+        data-number="{{num}}"
+    >
+        {{#singleheader}}
+            {{$ core_courseformat/local/content/section/header }}
+                {{> core_courseformat/local/content/section/header }}
+            {{/ core_courseformat/local/content/section/header }}
+        {{/singleheader}}
+        {{#header}}
+            {{$ core_courseformat/local/content/section/header }}
+                {{> core_courseformat/local/content/section/header }}
+            {{/ core_courseformat/local/content/section/header }}
+        {{/header}}
+        {{^singleheader}}
+            {{#restrictionlock}}
+                <div class="align-self-center ms-2">
+                    {{#pix}}t/unlock, core{{/pix}}
+                </div>
+            {{/restrictionlock}}
+        {{/singleheader}}
+        <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
+            {{$ core_courseformat/local/content/section/badges }}
+                {{> core_courseformat/local/content/section/badges }}
+            {{/ core_courseformat/local/content/section/badges }}
+        </div>
+
+        <div class="{{#hasavailability}}description{{/hasavailability}} my-3" data-for="sectioninfo">
+            {{#isstealth}}
+            <div class="alert alert-warning">
+                {{#str}} orphansectionwarning, core_courseformat {{/str}}
+            </div>
+            {{/isstealth}}
+            {{#summary}}
+                {{$ core_courseformat/local/content/section/summary }}
+                    {{> core_courseformat/local/content/section/summary }}
+                {{/ core_courseformat/local/content/section/summary }}
+            {{/summary}}
+            {{#availability}}
+                {{$ core_courseformat/local/content/section/availability }}
+                    {{> core_courseformat/local/content/section/availability }}
+                {{/ core_courseformat/local/content/section/availability }}
+            {{/availability}}
+        </div>
+        {{#cmsummary}}
+            {{$ core_courseformat/local/content/section/cmsummary }}
+                {{> core_courseformat/local/content/section/cmsummary }}
+            {{/ core_courseformat/local/content/section/cmsummary }}
+        {{/cmsummary}}
+        {{#cmlist}}
+            {{$ core_courseformat/local/content/section/cmlist }}
+                {{> core_courseformat/local/content/section/cmlist }}
+            {{/ core_courseformat/local/content/section/cmlist }}
+        {{/cmlist}}
+        {{{cmcontrols}}}
+    </div>
+{{/displayonesection}}

--- a/templates/core_courseformat/local/content/section/header.mustache
+++ b/templates/core_courseformat/local/content/section/header.mustache
@@ -1,0 +1,62 @@
+    {{!
+        This file is part of Moodle - http://moodle.org/
+
+        Moodle is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        Moodle is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+    }}
+    {{!
+        @template core_courseformat/local/content/section/header
+
+        Displays a course section header.
+
+        Example context (json):
+        {
+            "id": 123,
+            "name": "Section title",
+            "title": "<a href=\"http://moodle/course/view.php?id=5#section-0\">Section title</a>",
+            "url": "#",
+            "headerdisplaymultipage": true,
+            "sectionbulk": true,
+            "editing": 0,
+            "headinglevel": 3
+        }
+    }}
+    {{#sectionbulk}}
+        {{$ core_courseformat/local/content/section/bulkselect }}
+            {{> core_courseformat/local/content/section/bulkselect }}
+        {{/ core_courseformat/local/content/section/bulkselect }}
+    {{/sectionbulk}}
+    {{#headerdisplaymultipage}}
+        {{^displayonesection}}
+            <h3 id="sectionid-{{id}}-title" class="h4 sectionname">
+                {{{title}}}
+            </h3>
+        {{/displayonesection}}
+    {{/headerdisplaymultipage}}
+    {{^headerdisplaymultipage}}
+        {{#sitehome}}
+            <h2 id="sectionid-{{id}}-title" class="h3 sectionname">
+                {{{title}}}
+            </h2>
+        {{/sitehome}}
+        {{^sitehome}}
+            {{^displayonesection}}
+                <div class="d-flex align-items-center position-relative">
+                    <h{{headinglevel}} class="h4 sectionname course-content-item d-flex align-self-stretch align-items-center mb-0"
+                        id="sectionid-{{id}}-title" data-for="section_title" data-id="{{id}}" data-number="{{num}}">
+                        {{{header.name}}}
+                    </h{{headinglevel}}>
+                </div>
+            {{/displayonesection}}
+        {{/sitehome}}
+    {{/headerdisplaymultipage}}


### PR DESCRIPTION
### JIRA link
[TD-5734](https://hee-tis.atlassian.net/browse/TD-5734)

### Description
Added mustache files to theme to implement nhsuk expander code.
Moodle version had button to expand next to text to link to the section. Nhsuk version uses button and text to expand/collapse
Added a link to sections after the expander header in line with nhsuk standard for expander buttons and titles.
some css updates.


### Screenshots
<img width="1166" height="839" alt="image" src="https://github.com/user-attachments/assets/5ef70171-f722-495e-b0be-c0eea5f04d39" />
<img width="585" height="840" alt="image" src="https://github.com/user-attachments/assets/eee7769f-e697-43fc-8a0e-b24ab74cf439" />
<img width="364" height="834" alt="image" src="https://github.com/user-attachments/assets/2cd19f9d-b61d-45f9-8bbe-12b2388f8cc8" />

While there are Axe and Wave errors relating to landmarks and roles, these pre-exist this PR and are not related to these changes.
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5734]: https://hee-tis.atlassian.net/browse/TD-5734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ