### PR TITLE
override boost focus styles with NHSUK styles

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1387,6 +1387,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 }
 
 @media (max-width: 37.49em) {
+
   .nhsuk-details.nhsuk-expander .section_link,
   .nhsuk-details.nhsuk-expander .summarytext,
   .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
@@ -1397,4 +1398,24 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 .section-item .nhsuk-expander .nhsuk-details__summary:focus .nhsuk-details__summary-text:before,
 .section-item .nhsuk-expander[open] .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
   background-color: transparent;
+}
+
+// override boost theme focus styles with NHSUK focus styles
+.aalink.focus,
+a.focus.autolink,
+.aalink:focus,
+a.autolink:focus,
+#page-footer a:not([class]).focus,
+#page-footer a:not([class]):focus,
+.arrow_link.focus,
+.arrow_link:focus,
+a:not([class]).focus,
+a:not([class]):focus,
+.activityinstance>a.focus,
+.activityinstance>a:focus {
+  outline: 4px solid #fff0;
+  color: #212b32;
+  background-color: #ffeb3b;
+  box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
+  text-decoration: none;
 }


### PR DESCRIPTION
### JIRA link
[TD-6275](https://hee-tis.atlassian.net/browse/TD-6275)

### Description
Boost theme included focus definitions in blue which superseded NHSUK yellow and black focus styles
Added rules to nhse.scss which mimic Boost definition and contain our styles

### Screenshots
Before:
<img width="823" height="689" alt="image" src="https://github.com/user-attachments/assets/f3a39163-8cd8-43d5-9b69-1cda151d098c" />

After
<img width="847" height="692" alt="image" src="https://github.com/user-attachments/assets/15780c2b-0825-476f-bbb4-c8e17d5001c1" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6275]: https://hee-tis.atlassian.net/browse/TD-6275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ