### PR TITLE
Feature/td 6289 add descriptions for admin url theme properties

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -104,7 +104,7 @@ class core_renderer extends \theme_boost\output\core_renderer
             $admin_link->url = new \moodle_url('/admin/search.php'); // Use the observed URL
             $admin_link->hasnotification = false;
             $admin_link->notificationcount = 0;
-            $admin_link->openInNewTab = false; // Or true, if you prefer it opens in a new tab
+            $admin_link->openInNewTab = false; 
 
             // Add this admin link to your customnavigation array
             // This ensures it gets rendered by your {{#customnavigation}} block in Mustache
@@ -180,6 +180,7 @@ class core_renderer extends \theme_boost\output\core_renderer
                 if (!isset($item['visible']) || $item['visible'] === true) {
                     $processed_item = new \stdClass();
                     $processed_item->title = $item['title'] ?? 'Untitled'; // Default title if missing
+                    $processed_item->openInNewTab = $item['openInNewTab'] ?? false; 
                     // Handle URLs - convert to moodle_url if internal, keep as string if external
                     if (isset($item['url']) && !empty($item['url'])) {
                         $item_url_path = $item['url']; // Store the raw URL from the API       
@@ -188,6 +189,7 @@ class core_renderer extends \theme_boost\output\core_renderer
                             $admin_url = get_config('theme_nhse', 'admin_url');
                             if (!empty($admin_url)) {
                                 $processed_item->url = $admin_url;
+                                $processed_item->openInNewTab = true;
                                 error_log("theme_nhse: Overriding 'Admin' URL with theme setting: {$processed_item->url}");
                             } else {
                                 // Fallback to original logic if theme setting is not configured
@@ -216,8 +218,7 @@ class core_renderer extends \theme_boost\output\core_renderer
                         error_log("theme_nhse: Item has empty or missing URL, defaulting to Moodle home.");
                     }
                     $processed_item->hasnotification = $item['hasNotification'] ?? false;
-                    $processed_item->notificationcount = $item['notificationCount'] ?? 0;
-                    $processed_item->openInNewTab = $item['openInNewTab'] ?? false; 
+                    $processed_item->notificationcount = $item['notificationCount'] ?? 0;                    
 
                     $processed_links[] = $processed_item;
                 } else {

--- a/lang/en/theme_nhse.php
+++ b/lang/en/theme_nhse.php
@@ -24,6 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+$string['admin_url_setting']                           = 'LH Admin URL';
+$string['admin_url_setting_desc']                      = 'The full URL for the Learning Hub Admin page. This will be used to populate the Admin link URL.';
 $string['advancedsettings']                            = 'Advanced settings';
 $string['api_base_url_setting']                        = 'LH OpenAPI Base URL';
 $string['api_base_url_setting_desc']                   = 'The base URL for the Learning Hub OpenAPI (e.g., https://lh-openapi.dev.local). This will be used to fetch user navigation data.';

--- a/templates/nav.mustache
+++ b/templates/nav.mustache
@@ -36,7 +36,7 @@
             {{!-- BEGIN: Custom Navigation items --}}
             {{#customnavigation}}
                 <li class="nhsuk-header__navigation-item nav-item" role="none"> {{!-- Added nhsuk-header__navigation-item and nav-item classes --}}
-                    <a class="nhsuk-header__navigation-link nav-link" href="{{url}}" role="menuitem"> {{!-- Added nhsuk-header__navigation-link and nav-link classes --}}
+                    <a class="nhsuk-header__navigation-link nav-link" href="{{url}}" role="menuitem" {{#openInNewTab}}target="_blank"{{/openInNewTab}}> {{!-- Added nhsuk-header__navigation-link and nav-link classes --}}
                         {{title}}
                         {{#hasnotification}}
                             <span class="nhsuk-tag nhsuk-tag--notification">{{notificationcount}}</span> {{!-- Used NHS.UK tag for consistency --}}


### PR DESCRIPTION
This update populates the form field title and description for the theme setting admin URL 
This update also hard codes the admin url to open in a new window to match the behaviour on the Learning Hub 

Before:
<img width="1204" height="693" alt="image" src="https://github.com/user-attachments/assets/d9cb2a46-b8c2-4840-a6bd-da53ee775137" />

After:
<img width="1211" height="633" alt="image" src="https://github.com/user-attachments/assets/a0d46e75-5f00-42b5-adbe-783576bb176b" />