### PR TITLE
remove surplus course navigation

### DIFF
--- a/templates/core_courseformat/local/content.mustache
+++ b/templates/core_courseformat/local/content.mustache
@@ -1,0 +1,217 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core_courseformat/local/content
+
+    Displays the complete course format.
+
+    Example context (json):
+    {
+        "initialsection": {
+                "num": 0,
+                "id": 34,
+                "cmlist": {
+                    "cms": [
+                        {
+                            "cmitem": {
+                                "cmformat": {
+                                    "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
+                                    "hasname": "true"
+                                },
+                                "id": 3,
+                                "cmid": 3,
+                                "module": "forum",
+                                "extraclasses": "newmessages",
+                                "anchor": "module-3"
+                            }
+                        }
+                    ],
+                    "hascms": true
+                },
+                "iscurrent": true,
+                "summary": {
+                    "summarytext": "Summary text!"
+                }
+            },
+        "sections": [
+            {
+                "num": 1,
+                "id": 35,
+                "header": {
+                    "name": "Section title",
+                    "url": "#"
+                },
+                "cmlist": {
+                    "cms": [
+                        {
+                            "cmitem": {
+                                "cmformat": {
+                                    "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Another forum</span></a>",
+                                    "hasname": "true"
+                                },
+                                "id": 4,
+                                "cmid": 4,
+                                "module": "forum",
+                                "extraclasses": "newmessages",
+                                "anchor": "module-4"
+                            }
+                        }
+                    ],
+                    "hascms": true
+                },
+                "iscurrent": true,
+                "summary": {
+                    "summarytext": "Summary text!"
+                }
+            },
+            {
+                "num": 4,
+                "id": 36,
+                "header": {
+                    "name": "Section 2 title",
+                    "url": "#"
+                },
+                "cmlist": {
+                    "cms": [
+                        {
+                            "cmitem": {
+                                "cmformat": {
+                                    "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Forum example</span></a>",
+                                    "hasname": "true"
+                                },
+                                "id": 5,
+                                "cmid": 5,
+                                "module": "forum",
+                                "extraclasses": "newmessages",
+                                "anchor": "module-5"
+                            }
+                        }
+                    ],
+                    "hascms": true
+                },
+                "iscurrent": true,
+                "summary": {
+                    "summarytext": "Summary text!"
+                }
+            }
+        ],
+        "format": "topics",
+        "title": "Course title example",
+            "hasnavigation": true,
+            "sectionnavigation": {
+            "hasprevious": true,
+            "previousurl": "#",
+            "larrow": "&#x25C4;",
+            "previousname": "Section 3",
+            "hasnext": true,
+            "rarrow": "&#x25BA;",
+            "nexturl": "#",
+            "nextname": "Section 5"
+        },
+        "sectionselector": {
+            "hasprevious": true,
+            "previousurl": "#",
+            "larrow": "&#x25C4;",
+            "previousname": "Section 3",
+            "hasnext": true,
+            "rarrow": "&#x25BA;",
+            "nexturl": "#",
+            "nextname": "Section 5",
+            "selector": "<select><option>Section 4</option></select>"
+        },
+        "sectionreturn": 1,
+        "singlesection": {
+            "num": 5,
+            "id": 37,
+            "header": {
+                "name": "Single Section Example",
+                "url": "#"
+            },
+            "cmlist": {
+                "cms": [
+                    {
+                        "cmitem": {
+                            "cmformat": {
+                                "cmname": "<a class=\"aalink\" href=\"#\"><span class=\"instancename\">Assign example</span></a>",
+                                "hasname": "true"
+                            },
+                            "id": 6,
+                            "cmid": 6,
+                            "module": "assign",
+                            "extraclasses": "",
+                            "anchor": "module-6"
+                        }
+                    }
+                ],
+                "hascms": true
+            },
+            "iscurrent": true,
+            "summary": {
+                "summarytext": "Summary text!"
+            }
+        }
+    }
+}}
+<div id="course-format-{{uniqid}}">
+    <h2 class="accesshide">{{{title}}}</h2>
+    {{{completionhelp}}}
+    <ul class="{{format}}" data-for="course_sectionlist">
+        {{#initialsection}}
+            {{$ core_courseformat/local/content/section }}
+                {{> core_courseformat/local/content/section }}
+            {{/ core_courseformat/local/content/section }}
+        {{/initialsection}}
+        {{#sections}}
+            {{$ core_courseformat/local/content/section }}
+                {{> core_courseformat/local/content/section }}
+            {{/ core_courseformat/local/content/section }}
+        {{/sections}}
+    </ul>
+    {{#hasnavigation}}
+    <div class="single-section">
+        <ul class="{{format}}">
+        {{#singlesection}}
+            {{$ core_courseformat/local/content/section }}
+                {{> core_courseformat/local/content/section }}
+            {{/ core_courseformat/local/content/section }}
+        {{/singlesection}}
+        </ul>
+        {{#sectionselector}}
+            {{$ core_courseformat/local/content/sectionselector }}
+                {{> core_courseformat/local/content/sectionselector }}
+            {{/ core_courseformat/local/content/sectionselector }}
+        {{/sectionselector}}
+    </div>
+    {{/hasnavigation}}
+    {{#numsections}}
+        {{^singlesection}}
+            {{$ core_courseformat/local/content/addsection}}
+                {{> core_courseformat/local/content/addsection}}
+            {{/ core_courseformat/local/content/addsection}}
+        {{/singlesection}}
+    {{/numsections}}
+    {{#bulkedittools}}
+        {{$ core_courseformat/local/content/bulkedittools}}
+            {{> core_courseformat/local/content/bulkedittools}}
+        {{/ core_courseformat/local/content/bulkedittools}}
+    {{/bulkedittools}}
+</div>
+{{#js}}
+require(['core_courseformat/local/content'], function(component) {
+    component.init('page', {}, {{sectionreturn}});
+});
+{{/js}}

--- a/templates/core_courseformat/local/content/section/content.mustache
+++ b/templates/core_courseformat/local/content/section/content.mustache
@@ -151,9 +151,6 @@
         </summary>
 
         <div class="nhsuk-details__text content">
-            <div class="section_link">
-                <a href="{{{header.url}}}">Go to {{{header.name}}}</a>
-            </div>
             <div class="{{#hasavailability}}description{{/hasavailability}} my-3" data-for="sectioninfo">
                 {{#isstealth}}
                 <div class="alert alert-warning">


### PR DESCRIPTION
### JIRA link
[TD-6303](https://hee-tis.atlassian.net/browse/TD-6303)

### Description
Removed "Go to section" link in theme mustache file
Added new theme mustache file to override learninghub-moodle-lts\course\format\templates\local\content.mustache and removed call to sectionnavigation at the top of the page

### Screenshots
<img width="1217" height="735" alt="image" src="https://github.com/user-attachments/assets/6455659c-54f1-40a9-be2a-a48b909a44ce" />
<img width="1222" height="825" alt="image" src="https://github.com/user-attachments/assets/8af650b7-eb66-4560-b6c2-3e5a6964c270" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6303]: https://hee-tis.atlassian.net/browse/TD-6303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ