### PR TITLE
Update to use theme property to create correct search action URL

### DIFF
--- a/templates/navbar_search.mustache
+++ b/templates/navbar_search.mustache
@@ -57,7 +57,7 @@
 <div class="nhsuk-header__content" id="content-header">    
     <div class="nhsuk-header__search">
         <div class="nhsuk-header__search-wrap" id="wrap-search">
-        <form class="nhsuk-header__search-form" id="search" action="https://learninghub.nhs.uk/search/results" method="get" role="search">
+        <form class="nhsuk-header__search-form" id="search" action="{{dotnet_base_url}}search/results" method="get" role="search">
             <label class="nhsuk-u-visually-hidden" for="search-field">Search the learning hub</label>
             <input class="nhsuk-search__input" id="search-field" name="term" type="search" placeholder="Search the learning hub" autocomplete="off">
             <ul id="search-field_listbox" class="nhsuk-list autosuggestion-menu" style="display:none"></ul>


### PR DESCRIPTION
### JIRA link
[TD-6430](url)

### Description
When using the search form in the navigation area, if the user entered a search term and then submitted the form by pressing enter or selecting the magnifying glass, the URL for the search action was hard coded to the live Learning Hub. I have amended the code so it creates the search path using the dotnet_base_url theme property.

### Screenshots
n/s

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
