### PR TITLE
remove header icons

### DIFF
--- a/templates/core/context_header.mustache
+++ b/templates/core/context_header.mustache
@@ -1,0 +1,70 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/context_header
+
+    Context header template.
+
+    Example context (json):
+    {
+        "heading": "<h2>Page title</h2>",
+        "prefix": "Page prefix",
+        "hasadditionalbuttons": true,
+        "additionalbuttons": [
+            {
+                "url": "http://example.com",
+                "title": "Button title",
+                "formattedimage": "http://example.com/image.jpg",
+                "attributes": [
+                    {
+                        "name": "data-attribute",
+                        "value": "attribute value"
+                    },
+                    {
+                        "name": "class",
+                        "value": "btn btn-primary"
+                    }
+                ]
+            }
+        ]
+    }
+}}
+<div class="page-context-header d-flex align-items-center mb-2">
+    <div class="page-header-headings">
+        {{#prefix}}
+        <div class="text-muted text-uppercase small line-height-3">
+            {{{prefix}}}
+        </div>
+        {{/prefix}}
+        {{{heading}}}
+    </div>
+    {{#hasadditionalbuttons}}
+    <div class="btn-group header-button-group mx-3">
+        {{#additionalbuttons}}
+            <a href="{{url}}" {{#attributes}} {{name}}="{{value}}" {{/attributes}}>
+                {{#page}}
+                    {{#pix}}{{formattedimage}}{{/pix}}
+                    <span class="header-button-title">{{title}}</span>
+                {{/page}}
+                {{^page}}
+                    <img src="{{formattedimage}}" alt="{{title}}">
+                {{/page}}
+            </a>
+        {{/additionalbuttons}}
+    </div>
+    {{/hasadditionalbuttons}}
+</div>


### PR DESCRIPTION
### JIRA link
[TD-5808](https://hee-tis.atlassian.net/browse/TD-5808)

### Description
Added templates\core\context_header.mustache to theme
This overrides lib\templates\context_header.mustache from core code
New version does not have the following code in it's header thus removing all header icons:

    {{#imagedata}}
    <div class="page-header-image">
        {{{imagedata}}}
    </div>
    {{/imagedata}}

### Screenshots
Before:
<img width="1284" height="792" alt="image" src="https://github.com/user-attachments/assets/af282e3d-2958-489e-a910-5cbd322ecc2e" />

After:
<img width="1239" height="778" alt="image" src="https://github.com/user-attachments/assets/6d64e97d-e094-4ca0-a952-d4bca34d0ed3" />

<img width="461" height="693" alt="image" src="https://github.com/user-attachments/assets/3571fa7d-f213-43b4-836f-026452ec2c83" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5808]: https://hee-tis.atlassian.net/browse/TD-5808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ