### PR TITLE
Feature/td 5818 activity arrows fix

### DIFF
--- a/config.php
+++ b/config.php
@@ -223,3 +223,8 @@ $THEME->usescourseindex = getenv("USES_COURSE_INDEX");
 $THEME->activityheaderconfig = [
     'notitle' => false
 ];
+
+// Override the arrows with empty strings to remove them from the data source.
+// This will cause $OUTPUT->larrow() and $OUTPUT->rarrow() to return nothing.
+$THEME->larrow = '';
+$THEME->rarrow = '';

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2025101301;
+$plugin->version = 2025101201;
 $plugin->release = '404.4.0';
 $plugin->maturity = MATURITY_BETA;
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2025091201;
+$plugin->version = 2025101301;
 $plugin->release = '404.4.0';
 $plugin->maturity = MATURITY_BETA;
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2025101201;
+$plugin->version = 2025091201;
 $plugin->release = '404.4.0';
 $plugin->maturity = MATURITY_BETA;
 


### PR DESCRIPTION
### JIRA link
[TD-5818](https://hee-tis.atlassian.net/browse/TD-5818)

### Description
Added values for rarrow and larrow to config.php
This overrides the logic in the core moodle code that places arrows.

### Screenshots
<img width="1227" height="813" alt="image" src="https://github.com/user-attachments/assets/2eb86b46-99f8-4b87-90b0-6f6c28c68a8b" />
<img width="365" height="857" alt="image" src="https://github.com/user-attachments/assets/f2c2dcfc-cfee-4252-b329-1f94e8e5f7e9" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5818]: https://hee-tis.atlassian.net/browse/TD-5818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ