### PR TITLE
added nhsuk focus styling to side menu

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1355,7 +1355,8 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
   display: none !important;
 }
 
-.activity-icon, .page-header-image {
+.activity-icon,
+.page-header-image {
   display: none;
 }
 
@@ -1371,50 +1372,55 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 
 /* Prevent width of white area of course pages being limited in width - to match header */
 @media (min-width: 768px) {
-    body.limitedwidth.pagelayout-course #page.drawers .main-inner,
-    body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
-    body.pagelayout-incourse #page.drawers .main-inner {
-        max-width: unset;
-    }
+
+  body.limitedwidth.pagelayout-course #page.drawers .main-inner,
+  body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
+  body.pagelayout-incourse #page.drawers .main-inner {
+    max-width: unset;
+  }
 }
 
 /* Remove padding to maximise the width of the white area of course pages and match header */
 /* Rules to apply when the menu is NOT open */
 @media (min-width: 768px) {
-    body.pagelayout-course #page.drawers:not(.show-drawer-left),
-    body.pagelayout-mycourses #page.drawers:not(.show-drawer-left),
-    body.pagelayout-incourse #page.drawers:not(.show-drawer-left) {
-        padding-left: 0;
-    }
+
+  body.pagelayout-course #page.drawers:not(.show-drawer-left),
+  body.pagelayout-mycourses #page.drawers:not(.show-drawer-left),
+  body.pagelayout-incourse #page.drawers:not(.show-drawer-left) {
+    padding-left: 0;
+  }
 }
 
 /* Rule to remove padding-right always */
 @media (min-width: 768px) {
-    body.pagelayout-course #page.drawers,
-    body.pagelayout-mycourses #page.drawers,
-    body.pagelayout-incourse #page.drawers {
-        padding-right: 0;
-    }
+
+  body.pagelayout-course #page.drawers,
+  body.pagelayout-mycourses #page.drawers,
+  body.pagelayout-incourse #page.drawers {
+    padding-right: 0;
+  }
 }
 
 /* Limit width of content area to prevent wide text area on course pages */
 @media (min-width: 768px) {
-    body.limitedwidth.pagelayout-course #page-wrapper #page #page-content,
-    body.limitedwidth.pagelayout-mycourses #page-wrapper #page #page-content,
-    body.pagelayout-incourse #page-wrapper #page #page-content {
-        max-width: 830px;
-    }
-    /* No limit required when displaying SCORM content inline */
-    body#page-mod-scorm-player #page-wrapper #page #page-content {
-      max-width: unset;
-    }
+
+  body.limitedwidth.pagelayout-course #page-wrapper #page #page-content,
+  body.limitedwidth.pagelayout-mycourses #page-wrapper #page #page-content,
+  body.pagelayout-incourse #page-wrapper #page #page-content {
+    max-width: 830px;
+  }
+
+  /* No limit required when displaying SCORM content inline */
+  body#page-mod-scorm-player #page-wrapper #page #page-content {
+    max-width: unset;
+  }
 }
 
 /* Remove rounded corners on course page white content area */
 body.limitedwidth.pagelayout-course #page.drawers .main-inner,
 body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
 body.pagelayout-incourse #page.drawers .main-inner {
-    border-radius: 0;
+  border-radius: 0;
 }
 
 .course-section .section-item {
@@ -1470,32 +1476,33 @@ a:not([class]):focus,
 
 /* Prevent table of certified users causing mobile view horizontal scrolling  */
 .mod_coursecertificate_issues_table table {
-    display: block;
-    overflow-x: auto;
+  display: block;
+  overflow-x: auto;
 }
 
 .drawer-toggles .drawer-toggler .btn:focus {
-    @include nhsuk-focused-button;
+  @include nhsuk-focused-button;
 }
 
 .drawerheader .aabtn.text-reset.d-flex.align-items-center.py-1.h-100.d-md-none,
 .drawerheader .drawerheadercontent {
-  display:none !important;
+  display: none !important;
 }
 
 .courseindex-item.d-flex:focus {
-  box-shadow:none;
+  box-shadow: none;
+
   a.courseindex-link {
     @include nhsuk-focused-text;
   }
 }
 
 .courseindex-section[role=treeitem]:not([aria-expanded=true]):focus {
-  box-shadow:none;
-  border-color:#fff0;
-  border-width: 0 0 0 3px ;
+  box-shadow: none;
+  border-color: #fff0;
+  border-width: 0 0 0 3px;
+
   .courseindex-section-title {
     @include nhsuk-focused-text;
   }
 }
-                   

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1506,3 +1506,11 @@ a:not([class]):focus,
     @include nhsuk-focused-text;
   }
 }
+
+a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
+  @include nhsuk-focused-button;
+}
+
+.nhsuk-header__rhscontent .nhsuk-account__login--link:focus {
+  @include nhsuk-focused-text;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1474,3 +1474,28 @@ a:not([class]):focus,
     overflow-x: auto;
 }
 
+.drawer-toggles .drawer-toggler .btn:focus {
+    @include nhsuk-focused-button;
+}
+
+.drawerheader .aabtn.text-reset.d-flex.align-items-center.py-1.h-100.d-md-none,
+.drawerheader .drawerheadercontent {
+  display:none !important;
+}
+
+.courseindex-item.d-flex:focus {
+  box-shadow:none;
+  a.courseindex-link {
+    @include nhsuk-focused-text;
+  }
+}
+
+.courseindex-section[role=treeitem]:not([aria-expanded=true]):focus {
+  box-shadow:none;
+  border-color:#fff0;
+  border-width: 0 0 0 3px ;
+  .courseindex-section-title {
+    @include nhsuk-focused-text;
+  }
+}
+                   

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1480,6 +1480,7 @@ a:not([class]):focus,
   overflow-x: auto;
 }
 
+/* Removing style focus and adding nhsuk focus for left hand side menu button */
 .drawer-toggles .drawer-toggler .btn:focus {
   @include nhsuk-focused-button;
 }
@@ -1507,10 +1508,12 @@ a:not([class]):focus,
   }
 }
 
+/* skip link focus colour */
 a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
   @include nhsuk-focused-button;
 }
 
+/* apply nhsuk focus to header account links */
 .nhsuk-header__rhscontent .nhsuk-account__login--link:focus {
   @include nhsuk-focused-text;
 }


### PR DESCRIPTION
### JIRA link
[TD-6337](https://hee-tis.atlassian.net/browse/TD-6337)

### Description
Updated scss adding nhsuk-focused-text and nhsuk-focused-button mixins to elements of the side menu. 
Button used for active areas that do not reload the page
Text used for links that do refresh the page

### Screenshots
<img width="1327" height="737" alt="image" src="https://github.com/user-attachments/assets/e3d0e78e-5e93-4e20-bb63-a263caa696f5" />
<img width="570" height="868" alt="image" src="https://github.com/user-attachments/assets/da100f15-7d11-49f3-a206-13200cbb9902" />
<img width="559" height="890" alt="image" src="https://github.com/user-attachments/assets/43cf9f3f-1df8-4003-bf10-cffc85bdf245" />
<img width="1327" height="880" alt="image" src="https://github.com/user-attachments/assets/3c1dd5cc-c842-423c-9141-41e67bca8376" />
<img width="557" height="886" alt="image" src="https://github.com/user-attachments/assets/f0bed886-53ac-4ff5-9671-0c51b903fc19" />
<img width="1328" height="887" alt="image" src="https://github.com/user-attachments/assets/39b81f57-d25b-435a-89a7-9d6318a43636" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6337]: https://hee-tis.atlassian.net/browse/TD-6337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ