### PR TITLE
Remove "My Courses" link and the associated home icon

### DIFF
--- a/templates/core/navbar.mustache
+++ b/templates/core/navbar.mustache
@@ -12,7 +12,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>
 }}
 {{!
     @template core/navbar

--- a/templates/core/navbar.mustache
+++ b/templates/core/navbar.mustache
@@ -65,13 +65,6 @@
 }}
 <nav class="nhsuk-breadcrumb header-maxwidth d-print-none" aria-label="{{#str}}breadcrumb, access{{/str}}">
     <ol class="nhsuk-breadcrumb__list">
-        {{^get_items}}
-            <li class="nhsuk-breadcrumb__item">
-                <a href="{{{config.homeurl}}}" class="nhsuk-breadcrumb__link">
-                    <span class="media-left"><i class="icon fa fa-home fa-fw" aria-hidden="true"></i>
-                </span>My courses</a>
-            </li>
-        {{/get_items}}
         {{#get_items}}
             {{#has_action}}
                 <li class="nhsuk-breadcrumb__item">


### PR DESCRIPTION
I have updated a theme mustache file to remove the "My Courses" link and the home icon that sits to the left of it. This is to prevent users selecting this to navigate to the Moodle start page.