### PR TITLE
Refactor to resolve incorrect URL

### DIFF
--- a/amd/src/autosuggest.js
+++ b/amd/src/autosuggest.js
@@ -38,7 +38,6 @@ define(['jquery'], function($) {
                                         originalTermForUrl: item.concept, // Used for the actualHref for concepts
                                         type: 'Concepts', // Matches 'Concepts' from .NET GetUrl searchType
                                         payload: item._click.payload, // Pass the whole payload for tracking URL
-                                        // originalItem: item // Keep original item for deeper inspection if needed
                                     });
                                 });
                             }
@@ -48,10 +47,9 @@ define(['jquery'], function($) {
                                 decodedResult.resources_documents.documents.forEach(item => {
                                     allSuggestions.push({
                                         displayTitle: item.title,
-                                        targetReferenceId: item.resourceReferenceId, // Use ResourceReferenceId as per .NET GetUrl
+                                        targetReferenceId: item.resource_reference_id, // Use ResourceReferenceId as per .NET GetUrl
                                         type: 'Resource', // Matches 'Resource' from .NET GetUrl searchType
-                                        payload: item._click.payload,
-                                        // originalItem: item
+                                        payload: item._click.payload
                                     });
                                 });
                             }
@@ -63,8 +61,7 @@ define(['jquery'], function($) {
                                         displayTitle: item.name, // Use 'name' for catalogues
                                         targetReference: item.url, // Use item.Url as per .NET GetUrl
                                         type: 'Catalogues', // Matches 'Catalogues' from .NET GetUrl searchType
-                                        payload: item._click.payload,
-                                        // originalItem: item
+                                        payload: item._click.payload
                                     });
                                 });
                             }
@@ -83,10 +80,9 @@ define(['jquery'], function($) {
 
                                 // Determine actualTargetUrl SVG path, and dimensions based on type, mimicking the .NET GetUrl logic
                                 if (item.type === 'Resource') {
-                                    if (item.targetReferenceId > 0) {
+                                    if (item.targetReferenceId && item.targetReferenceId > 0) {
                                         actualTargetUrl = `/Resource/${item.targetReferenceId}`;
-                                    } else {
-                                        // Fallback, though .NET only had ResourceReferenceId > 0
+                                    } else {                                        
                                         actualTargetUrl = `/Search/results?term=${encodeURIComponent(item.displayTitle)}`;
                                     }
                                     typeClass = 'autosugg-resource';
@@ -96,10 +92,9 @@ define(['jquery'], function($) {
                                     svgWidth = '16';
                                     svgHeight = '12';
                                 } else if (item.type === 'Catalogues') {
-                                    if (item.targetReference && item.targetReference.length > 0) {
+                                    if (item.targetReference) {
                                         actualTargetUrl = `/Catalogue/${item.targetReference}`;
                                     } else {
-                                        // Fallback if reference missing
                                         actualTargetUrl = `/Search/results?term=${encodeURIComponent(item.displayTitle)}`;
                                     }
                                     typeClass = 'autosugg-catalogue';


### PR DESCRIPTION
### JIRA link
[TD-6382](https://hee-tis.atlassian.net/browse/TD-6382)

### Description
When searching via the search bar in the header and the autosuggestions, when selecting the autosuggestions for resources and catalogues, it was navigating to the wrong URL. I have resolved this by refactoring the conditionals.

### Screenshots
n/a
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6382]: https://hee-tis.atlassian.net/browse/TD-6382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ