### PR TITLE
Feature/td 6393 moodle theme add underline to footer links

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1468,8 +1468,6 @@ body.pagelayout-incourse #page.drawers .main-inner {
 a.focus.autolink,
 .aalink:focus,
 a.autolink:focus,
-#page-footer a:not([class]).focus,
-#page-footer a:not([class]):focus,
 .arrow_link.focus,
 .arrow_link:focus,
 a:not([class]).focus,
@@ -1481,6 +1479,17 @@ a:not([class]):focus,
   background-color: #ffeb3b;
   box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
   text-decoration: none;
+}
+
+// Force the underline onto the NHSUK footer links, overriding the design system's default 'text-decoration: none'.
+.nhsuk-footer__list-item-link {
+    text-decoration: underline !important;
+}
+
+// Remove the underline on hover and focus
+.nhsuk-footer__list-item-link:hover,
+.nhsuk-footer__list-item-link:focus {
+    text-decoration: none !important;
 }
 
 /* Prevent table of certified users causing mobile view horizontal scrolling  */


### PR DESCRIPTION
### JIRA link
[TD-6393](https://hee-tis.atlassian.net/browse/TD-6393)

### Description
This update removes some redundant SCSS that targeted a non existent div id and it adds SCSS to ensure the footer links have underline by default, remove underline when in hover and focus state. This will likely be removed when the Moodle them gets updated to the NHS UK Frontend V10

### Screenshots
<img width="726" height="202" alt="image" src="https://github.com/user-attachments/assets/5d4c64ca-ebc1-436f-ac10-98935c606b07" />

<img width="702" height="109" alt="image" src="https://github.com/user-attachments/assets/c57767e6-f723-4035-98ea-b0b709272a55" />

<img width="744" height="92" alt="image" src="https://github.com/user-attachments/assets/939add55-4ec7-4e3e-8ff8-5d1cefbf4344" />



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6393]: https://hee-tis.atlassian.net/browse/TD-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ