### PR TITLE
Add nhsuk focus state to activity status buttons

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1531,3 +1531,12 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 .nav-tabs .nhsuk-header__navigation-link.dropdown-item:focus {
   @include nhsuk-focused-text;
 }
+
+.activity-item .activity-completion button.btn:focus,
+.activity-item .activity-completion button.btn.focus,
+.activity-item .activity-completion button.btn-success:focus,
+.activity-item .activity-completion button.btn:focus,
+.activity-item .activity-completion a[role=button].btn:focus,
+.activity-item .activity-completion a[role=button].btn.focus {
+  @include nhsuk-focused-button;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1532,6 +1532,7 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
   @include nhsuk-focused-text;
 }
 
+/* focus colour on activity completion buttons */
 .activity-item .activity-completion button.btn:focus,
 .activity-item .activity-completion button.btn.focus,
 .activity-item .activity-completion button.btn-success:focus,


### PR DESCRIPTION
### JIRA link
[TD-6364](https://hee-tis.atlassian.net/browse/TD-6364)

### Description
Added nhsuk mixin to activity status buttons, overriding existing focus states.

### Screenshots
<img width="1054" height="841" alt="image" src="https://github.com/user-attachments/assets/d40c5d10-0112-4fce-a193-3fb345dec526" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6364]: https://hee-tis.atlassian.net/browse/TD-6364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ