### PR TITLE
add open status to first expander and fix nested expander styles

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1571,3 +1571,17 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
     background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
   }
 }
+
+.nhsuk-expander .activity.subsection.modtype_subsection > .activity-item {
+    border: none; 
+    margin: 0;
+}
+
+.nhsuk-expander .activity.subsection.modtype_subsection > .activity-item .section-item {
+    margin-top:0;
+    margin-bottom:0;
+}
+
+.nhsuk-expander .nhsuk-details.nhsuk-expander {
+  margin-bottom: 0;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1550,3 +1550,24 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 .activity-item .activity-completion a[role=button].btn.focus {
   @include nhsuk-focused-button;
 }
+
+/* make the expander button respond to it's direct parent, not any parent. Stops nested expander plus/minus buttons from misbehaving */
+
+.nhsuk-expander[open] .nhsuk-expander {
+
+  &:not([open]) .nhsuk-details__summary-text::before {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+  }
+
+  &:not([open]) .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+  }
+
+  &[open] .nhsuk-details__summary-text::before {
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23005eb8'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+  }
+
+  &[open] .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
+    background: $nhsuk-focus-color url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23002f5c'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+  }
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1572,6 +1572,8 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
   }
 }
 
+/* removal of border around nested expanders and reducing vertical padding */
+
 .nhsuk-expander .activity.subsection.modtype_subsection > .activity-item {
     border: none; 
     margin: 0;

--- a/templates/core_courseformat/local/content/section/content.mustache
+++ b/templates/core_courseformat/local/content/section/content.mustache
@@ -92,6 +92,7 @@
         data-for="section_title"
         data-id="{{id}}"
         data-number="{{num}}"
+        {{^contentcollapsed}}open{{/contentcollapsed}}
     >
         <summary class="nhsuk-details__summary">
             <span class="nhsuk-details__summary-text">


### PR DESCRIPTION
### JIRA link
[TD-6362](https://hee-tis.atlassian.net/browse/TD-6362)

### Description
New rules added for nested expanders as existing rules looked to any parent that was "open" or not. New rules define nested expander status. (fix 1 and 2 below)

content.mustache updated to include "open" setting on expanders as required. Matching old code that placed a "show" tag in the base theme (fix 3 below)

css fixes for vertical spacing of nested expanders, also removed unnecessary rounded edge border. This is shown in Fix 4 below ONLY, first screenshots show how it looked before this extra commit added.

### Screenshots
Fix 1: nested expanders have correct icon when page loaded. Previously took same icon as parent (ie open)
Also focus colours tested
<img width="1358" height="757" alt="image" src="https://github.com/user-attachments/assets/b415818c-8d5c-43f0-83c7-e79a1637c9a3" />
<img width="1351" height="745" alt="image" src="https://github.com/user-attachments/assets/48485250-852d-4212-98b3-9c07212723df" />

Fix 2: nested expanders icons respond to being opened. Previously maintained parent icon state regardless of their own status
<img width="1358" height="844" alt="image" src="https://github.com/user-attachments/assets/d7c6c177-5e3f-44c7-b3de-adf41898b596" />
<img width="1566" height="984" alt="image" src="https://github.com/user-attachments/assets/82042415-dd27-45f1-a49a-45896f77564f" />

Fix 3: First expander on a page now loads in open state
<img width="1988" height="1498" alt="image" src="https://github.com/user-attachments/assets/a8225c89-a786-4b7f-9913-039414c77907" />

Fix 4: Reduced vertical spacing on nested expanders:
<img width="1830" height="1374" alt="image" src="https://github.com/user-attachments/assets/b8bfef06-dba7-4f86-9e2e-b15e197a13f1" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6362]: https://hee-tis.atlassian.net/browse/TD-6362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ