### PR TITLE
Add additional page type to allow wider content area

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1373,6 +1373,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 /* Prevent width of white area of course pages being limited in width - to match header */
 @media (min-width: 768px) {    
     body.pagelayout-base #page.drawers .main-inner,
+    body.limitedwidth.pagelayout-frontpage #page.drawers .main-inner,
     body.limitedwidth.pagelayout-coursecategory #page.drawers .main-inner,
     body.limitedwidth.pagelayout-course #page.drawers .main-inner,
     body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
@@ -1385,6 +1386,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 /* Rules to apply when the menu is NOT open */
 @media (min-width: 768px) {
     body.pagelayout-base #page.drawers:not(.show-drawer-left),
+    body.pagelayout-frontpage #page.drawers:not(.show-drawer-left),
     body.pagelayout-coursecategory #page.drawers:not(.show-drawer-left),
     body.pagelayout-course #page.drawers:not(.show-drawer-left),
     body.pagelayout-mycourses #page.drawers:not(.show-drawer-left),
@@ -1396,6 +1398,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 /* Rule to remove padding-right always */
 @media (min-width: 768px) {
     body.pagelayout-base #page.drawers,
+    body.pagelayout-frontpage #page.drawers,
     body.pagelayout-coursecategory #page.drawers,
     body.pagelayout-course #page.drawers,
     body.pagelayout-mycourses #page.drawers,
@@ -1407,6 +1410,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 /* Limit width of content area to prevent wide text area on course pages */
 @media (min-width: 768px) {
     body.pagelayout-base #page-wrapper #page #page-content,
+    body.limitedwidth.pagelayout-frontpage #page-wrapper #page #page-content,
     body.limitedwidth.pagelayout-coursecategory #page-wrapper #page #page-content,
     body.limitedwidth.pagelayout-course #page-wrapper #page #page-content,
     body.limitedwidth.pagelayout-mycourses #page-wrapper #page #page-content,
@@ -1421,6 +1425,7 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 
 /* Remove rounded corners on course page white content area */
 body.pagelayout-base #page.drawers .main-inner,
+body.limitedwidth.pagelayout-frontpage #page.drawers .main-inner,
 body.limitedwidth.pagelayout-coursecategory #page.drawers .main-inner,
 body.limitedwidth.pagelayout-course #page.drawers .main-inner,
 body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,


### PR DESCRIPTION
### JIRA link
[TD-6420](https://hee-tis.atlassian.net/browse/TD-6420)

### Description
Testing revealed a page type that was still displaying a narrow content area. I have added SCSS to target this.

### Screenshots
<img width="1549" height="860" alt="image" src="https://github.com/user-attachments/assets/44dd3d05-b460-404b-9f53-9a8d3641040e" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6420]: https://hee-tis.atlassian.net/browse/TD-6420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ