### PR TITLE
Apply styling for NHS UK Frontend style checkbox for course mgt page

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1371,56 +1371,61 @@ body.simulated-fullscreen .d-flex.flex-row-reverse.mb-2 a.btn.btn-secondary[titl
 }
 
 /* Prevent width of white area of course pages being limited in width - to match header */
-@media (min-width: 768px) {    
-    body.pagelayout-base #page.drawers .main-inner,
-    body.limitedwidth.pagelayout-frontpage #page.drawers .main-inner,
-    body.limitedwidth.pagelayout-coursecategory #page.drawers .main-inner,
-    body.limitedwidth.pagelayout-course #page.drawers .main-inner,
-    body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
-    body.pagelayout-incourse #page.drawers .main-inner {
-        max-width: unset;
-    }
+@media (min-width: 768px) {
+
+  body.pagelayout-base #page.drawers .main-inner,
+  body.limitedwidth.pagelayout-frontpage #page.drawers .main-inner,
+  body.limitedwidth.pagelayout-coursecategory #page.drawers .main-inner,
+  body.limitedwidth.pagelayout-course #page.drawers .main-inner,
+  body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
+  body.pagelayout-incourse #page.drawers .main-inner {
+    max-width: unset;
+  }
 }
 
 /* Remove padding to maximise the width of the white area of course pages and match header */
 /* Rules to apply when the menu is NOT open */
 @media (min-width: 768px) {
-    body.pagelayout-base #page.drawers:not(.show-drawer-left),
-    body.pagelayout-frontpage #page.drawers:not(.show-drawer-left),
-    body.pagelayout-coursecategory #page.drawers:not(.show-drawer-left),
-    body.pagelayout-course #page.drawers:not(.show-drawer-left),
-    body.pagelayout-mycourses #page.drawers:not(.show-drawer-left),
-    body.pagelayout-incourse #page.drawers:not(.show-drawer-left) {
-        padding-left: 0;
-    }
+
+  body.pagelayout-base #page.drawers:not(.show-drawer-left),
+  body.pagelayout-frontpage #page.drawers:not(.show-drawer-left),
+  body.pagelayout-coursecategory #page.drawers:not(.show-drawer-left),
+  body.pagelayout-course #page.drawers:not(.show-drawer-left),
+  body.pagelayout-mycourses #page.drawers:not(.show-drawer-left),
+  body.pagelayout-incourse #page.drawers:not(.show-drawer-left) {
+    padding-left: 0;
+  }
 }
 
 /* Rule to remove padding-right always */
 @media (min-width: 768px) {
-    body.pagelayout-base #page.drawers,
-    body.pagelayout-frontpage #page.drawers,
-    body.pagelayout-coursecategory #page.drawers,
-    body.pagelayout-course #page.drawers,
-    body.pagelayout-mycourses #page.drawers,
-    body.pagelayout-incourse #page.drawers {
-        padding-right: 0;
-    }
+
+  body.pagelayout-base #page.drawers,
+  body.pagelayout-frontpage #page.drawers,
+  body.pagelayout-coursecategory #page.drawers,
+  body.pagelayout-course #page.drawers,
+  body.pagelayout-mycourses #page.drawers,
+  body.pagelayout-incourse #page.drawers {
+    padding-right: 0;
+  }
 }
 
 /* Limit width of content area to prevent wide text area on course pages */
 @media (min-width: 768px) {
-    body.pagelayout-base #page-wrapper #page #page-content,
-    body.limitedwidth.pagelayout-frontpage #page-wrapper #page #page-content,
-    body.limitedwidth.pagelayout-coursecategory #page-wrapper #page #page-content,
-    body.limitedwidth.pagelayout-course #page-wrapper #page #page-content,
-    body.limitedwidth.pagelayout-mycourses #page-wrapper #page #page-content,
-    body.pagelayout-incourse #page-wrapper #page #page-content {
-        max-width: 830px;
-    }
-    /* No limit required when displaying SCORM content inline */
-    body#page-mod-scorm-player #page-wrapper #page #page-content {
-      max-width: unset;
-    }
+
+  body.pagelayout-base #page-wrapper #page #page-content,
+  body.limitedwidth.pagelayout-frontpage #page-wrapper #page #page-content,
+  body.limitedwidth.pagelayout-coursecategory #page-wrapper #page #page-content,
+  body.limitedwidth.pagelayout-course #page-wrapper #page #page-content,
+  body.limitedwidth.pagelayout-mycourses #page-wrapper #page #page-content,
+  body.pagelayout-incourse #page-wrapper #page #page-content {
+    max-width: 830px;
+  }
+
+  /* No limit required when displaying SCORM content inline */
+  body#page-mod-scorm-player #page-wrapper #page #page-content {
+    max-width: unset;
+  }
 }
 
 /* Remove rounded corners on course page white content area */
@@ -1489,8 +1494,8 @@ a:not([class]):focus,
 /*
  * Ensure footer links are underlined to match LH styling
  */
-#nhsuk-footer .nhsuk-footer__list-item-link {   
-    text-decoration: underline;
+#nhsuk-footer .nhsuk-footer__list-item-link {
+  text-decoration: underline;
 }
 
 /*
@@ -1498,7 +1503,7 @@ a:not([class]):focus,
  */
 #nhsuk-footer .nhsuk-footer__list-item-link:hover,
 #nhsuk-footer .nhsuk-footer__list-item-link:focus {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 /* Prevent table of certified users causing mobile view horizontal scrolling  */
@@ -1583,16 +1588,67 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 
 /* removal of border around nested expanders and reducing vertical padding */
 
-.nhsuk-expander .activity.subsection.modtype_subsection > .activity-item {
-    border: none; 
-    margin: 0;
+.nhsuk-expander .activity.subsection.modtype_subsection>.activity-item {
+  border: none;
+  margin: 0;
 }
 
-.nhsuk-expander .activity.subsection.modtype_subsection > .activity-item .section-item {
-    margin-top:0;
-    margin-bottom:0;
+.nhsuk-expander .activity.subsection.modtype_subsection>.activity-item .section-item {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .nhsuk-expander .nhsuk-details.nhsuk-expander {
   margin-bottom: 0;
+}
+
+/* ---------------------------------------------------------------------------------- */
+/* COURSE MANAGEMENT CHECKBOX STYLING
+/* ---------------------------------------------------------------------------------- */
+
+#page-course-management input.custom-control-input:focus {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  outline: none !important
+}
+
+#page-course-management #page-content .custom-control-label::before {
+  width: 2rem;
+  height: 2rem;
+  top: 0;
+}
+
+#page-course-management #page-content .custom-checkbox.me-1 {
+  margin-right: 1.25rem !important;
+}
+
+#page-course-management #page-content .custom-control-input:focus~.custom-control-label::before {
+  border-width: 4px !important;
+  border-color: #212b32 !important;
+  border-style: solid !important;
+  box-shadow: 0 0 0 4px #ffeb3b !important;
+  outline: none !important;
+  outline: 4px solid transparent !important;
+  outline-offset: 1px !important;
+}
+
+#page-course-management .custom-control.custom-checkbox .custom-control-label::before {
+  border: 2px solid #0b0c0c !important;
+  border-radius: 0 !important;
+}
+
+#page-course-management #page-content .custom-control-label::after {
+  top: 0rem;
+  left: -1.5rem;
+  width: 2rem;
+  height: 2rem;
+}
+
+#page-course-management #page-content .custom-checkbox .custom-control-input:checked~.custom-control-label::after {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%23000' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/%3e%3c/svg%3e");
+}
+
+#page-course-management #page-content .custom-control-input:checked~.custom-control-label::before {
+  background-color: #fff;
 }


### PR DESCRIPTION
### JIRA link
[TD-6404](https://hee-tis.atlassian.net/browse/TD-6404)

### Description
Addition of SCSS targeting the checkbox element on the course management page. The result is the checkbox UI element appears larger with a square box and focus style the same as the NHS UK Frontend. 

I use this link on my local Moodle to get to a page to test

https://lh-moodle.dev.local/course/management.php?categoryid=1

### Screenshots

<img width="513" height="428" alt="image" src="https://github.com/user-attachments/assets/62a45550-bf89-4fa6-859f-f2915aad0e8e" />

<img width="427" height="340" alt="image" src="https://github.com/user-attachments/assets/7940612d-2099-4ecb-be67-d996303665fa" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6404]: https://hee-tis.atlassian.net/browse/TD-6404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ