### PR TITLE
Bugfix/td 6544 moodle theme footer link alignment on mobile

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1491,19 +1491,103 @@ a:not([class]):focus,
   text-decoration: none;
 }
 
+/* ------------------------------------------------------------------------------------------ */
+/* FOOTER                                                                                     */
+/* Some of this can be removed when theme updated to v10 NHS UK Frontend
+/* ------------------------------------------------------------------------------------------ */
+
+.nhsuk-footer {
+  background-color: #d8dde0;
+  border-top: 4px solid #005eb8;
+}
+
+.nhsuk-footer {
+  padding-top: 24px;
+}
+
+@media (min-width: 40.0625em) {
+  .nhsuk-footer {
+    padding-top: 32px;
+  }
+}
+
+.nhsuk-footer .nhsuk-width-container {
+  margin-left: 16px;  /* or 32px for larger screens */
+  margin-right: 16px;
+}
+
+
+@media (min-width: 48.0625em) {
+  .nhsuk-footer .nhsuk-width-container {
+    margin-left: 24px;
+    margin-right: 24px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .nhsuk-footer .nhsuk-width-container {
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
+.nhsuk-footer .nhsuk-footer-container {
+  background-color: transparent;
+  border-top: none;
+  width: 100%;
+}
+
+.nhsuk-footer .nhsuk-footer__list {
+  float: none; /* cancel v9 float */
+  width: auto;  /* allow list to take full width */
+  padding-right: 0;
+  padding-bottom: 0;
+}
+
+@media (min-width: 48.0625em) {
+  .nhsuk-footer__meta .nhsuk-footer__list-item {
+    display: inline-block;
+    margin-right: 32px;
+  }
+}
+
+/* Override v9 mobile footer border + padding */
+.nhsuk-footer .nhsuk-footer__meta {
+  border-top: none !important;
+  padding-top: 0 !important;
+}
+
 /*
  * Ensure footer links are underlined to match LH styling
  */
-#nhsuk-footer .nhsuk-footer__list-item-link {
+.nhsuk-footer .nhsuk-footer__list-item-link {
   text-decoration: underline;
 }
 
 /*
  * Match focus and hover state to LH styling
  */
-#nhsuk-footer .nhsuk-footer__list-item-link:hover,
-#nhsuk-footer .nhsuk-footer__list-item-link:focus {
+.nhsuk-footer .nhsuk-footer__list-item-link:hover,
+.nhsuk-footer .nhsuk-footer__list-item-link:focus {
   text-decoration: none;
+}
+
+
+.nhsuk-footer .nhsuk-body-s {
+  display: block;
+  font-size: .875rem;
+  line-height: 1.71429;
+  margin-top: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .nhsuk-footer .nhsuk-body-s {
+    font-size: 1rem;
+    line-height: 1.5;
+  }
 }
 
 /* Prevent table of certified users causing mobile view horizontal scrolling  */

--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -3,8 +3,8 @@
 
     Moodle is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+    the Free Software Foundation, either version 3 of the License, or,
+    at your option, any later version.
 
     Moodle is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -12,49 +12,51 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+    along with Moodle. If not, see <http://www.gnu.org/licenses/>.
 }}
+
 {{!
     @template theme_nhse/footer
-
-    Page fooer template
-
-    Example context (json):
-    {
-        "output": {
-            "page_doc_link": "Help and documentation",
-            "supportemail": "<a href=\"#\">Contact site support</a>",
-            "has_popover_links": true,
-            "services_support": "Services and support",
-            "login_info": "You are logged in as cute kitten",
-            "moodle_release": "90210"
-        }
-    }
+    Fully NHSUK Frontend v10 compliant footer, matching the service manual
 }}
-<footer role="contentinfo" id="nhsuk-footer">
-    <div class="nhsuk-footer-container">
-        <div class="nhsuk-width-container footer-content-popover container" data-region="footer-content-popover">
-            <div class="nhsuk-width-container">
+
+<footer class="nhsuk-footer" role="contentinfo">
+    <div class="nhsuk-width-container">
+        <div class="nhsuk-footer__meta">
+            <!-- Accessible heading for screen readers -->
             <h2 class="nhsuk-u-visually-hidden">Support links</h2>
-                <ul class="nhsuk-footer__list">
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" target="_blank" href="https://support.learninghub.nhs.uk/support/home">Help</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Contactus">Contact us</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Aboutus">About us</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Updates">Service updates and releases</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/NHSsites">NHS sites</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Policies">Our policies</a></li>
-                    <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item"><a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Accessibility">Accessibility statement</a></li>
-                </ul>
-            <div class="nhsuk-u-float-right">
-                <p class="nhsuk-footer__copyright">© NHS England</p>
-            </div>
+
+            <!-- Primary footer links -->
+            <ul class="nhsuk-footer__list">
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="https://support.learninghub.nhs.uk/support/home" target="_blank">Help</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Contactus">Contact us</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Aboutus">About us</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Updates">Service updates and releases</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/NHSsites">NHS sites</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Policies">Our policies</a>
+                </li>
+                <li class="nhsuk-footer__list-item">
+                    <a class="nhsuk-footer__list-item-link" href="{{dotnet_base_url}}Home/Accessibility">Accessibility statement</a>
+                </li>
+            </ul>
+
+            <!-- Footer metadata / copyright -->
+            <p class="nhsuk-body-s">© NHS England</p>
+
+            <!-- Moodle scripts / injected HTML -->
             {{{ output.standard_end_of_body_html }}}
         </div>
     </div>
 </footer>
-{{#js}}
-require(['theme_boost/footer-popover'], function(FooterPopover) {
-    FooterPopover.init();
-});
-{{/js}}
 


### PR DESCRIPTION
### JIRA link
[TD-6544](https://hee-tis.atlassian.net/browse/TD-6544)

### Description
In the process of resolving an issue with the footer links not aligning to the left correctly when viewed at approx tablet size, I have refactored the footer.mustache file to use markup from the latest v10 service manual footer. As the theme is still using v9 NHS UK Frontend (via the TEL-Frontend fork of this) I have add to add a chunk of SCSS to sort the styling. A lot of this will be removed when the theme has been updated to v10.

Note I have implemented the copyright name on a new line left aligned similar to how the latest footer in the service manual does this. The current LH has it floated to the right so there will be a minor disparity until the LH is updated to v10.



### Screenshots
<img width="1059" height="611" alt="image" src="https://github.com/user-attachments/assets/aa1f90b5-654e-4146-8001-2ea1895171d9" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6544]: https://hee-tis.atlassian.net/browse/TD-6544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ