### PR TITLE
Fix issue with selected state background colour

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1652,3 +1652,7 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 #page-course-management #page-content .custom-control-input:checked~.custom-control-label::before {
   background-color: #fff;
 }
+
+#page-course-management #page-content .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: initial;
+}


### PR DESCRIPTION
### JIRA link
[TD-6545](https://hee-tis.atlassian.net/browse/TD-6545)

### Description
A recent update to the check box UI on the course management page was tested and it was discovered the checkbox bg was going blue when selected which fails accessibility contrast check. I have added SCSS to resolve this.

### Screenshots
<img width="506" height="391" alt="image" src="https://github.com/user-attachments/assets/6b275104-9548-4187-bdaf-c46b77cbbd5b" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6545]: https://hee-tis.atlassian.net/browse/TD-6545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ