### PR TITLE
Adjust position of LHS toggle menu. Add padding to prevent overlap

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -288,20 +288,6 @@ body {
   }
 }
 
-.drawer-toggles {
-  .drawer-toggler {
-    top: calc(140px + 0.7rem)
-  }
-}
-
-@media (max-width: 991.98px) {
-  .drawer-toggles {
-    .drawer-toggler {
-      top: calc(99vh - (60px * 2.5))
-    }
-  }
-}
-
 .drawercontent {
   height: calc(100% - 124px);
 
@@ -1438,6 +1424,14 @@ body.pagelayout-incourse #page.drawers .main-inner {
   border-radius: 0;
 }
 
+/* Course page content area padding to allow room for left hand side menu toggle */
+body.limitedwidth.pagelayout-course #page-wrapper #page .main-inner,
+body.pagelayout-incourse #page-wrapper #page .main-inner,
+body.pagelayout-report #page-wrapper #page .main-inner {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+}
+
 
 
 
@@ -1515,6 +1509,11 @@ a:not([class]):focus,
 /* Removing style focus and adding nhsuk focus for left hand side menu button */
 .drawer-toggles .drawer-toggler .btn:focus {
   @include nhsuk-focused-button;
+}
+
+/* Prevent boost CSS affecting the toggle button position */
+#page .drawer-toggles .drawer-toggler {
+    top: unset; /* prevent static CSS from interfering */
 }
 
 .drawerheader .aabtn.text-reset.d-flex.align-items-center.py-1.h-100.d-md-none,


### PR DESCRIPTION
### JIRA link
[TD-6489](https://hee-tis.atlassian.net/browse/TD-6489)

### Description
Testing revealed an issue where the left hand side menu toggle button was not visible on tablet in portrait mode. Investigation revealed this was due to some SCSS in the theme using a fixed vertical offset. As the header height in our theme can increase, the header was obscuring the the toggle button.

I have removed the SCSS that was using this hard coded vertical positioning and just let it position naturally. 

I noticed the toggle button was overlapping content such as the Course title so I have introduced some left and right hand side padding to prevent this. I have applied this to 3 different page types. Not sure if our users will see all 3 page types but no harm in adding these. There may be additional pages this could have been added to for Admin users but I will leave this for now and see if this is ever flagged as an issue. 

Ignore the header in this grab as there is a separate branch that tidies up the header UI.

### Screenshots
<img width="378" height="500" alt="image" src="https://github.com/user-attachments/assets/d1000434-6fec-47fd-9d48-5d5a04e72005" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6489]: https://hee-tis.atlassian.net/browse/TD-6489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ