### PR TITLE
Bugfix/td 6339 overlapping issue in mobile view when searching with a term on search box on moodle course screen

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1246,7 +1246,7 @@ td {
   overflow-y: auto;
   position: absolute;
   width: 100%;
-  z-index: 1;
+  z-index: 20;
   margin-bottom: 0;
   top:100%;
 }

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1248,6 +1248,7 @@ td {
   width: 100%;
   z-index: 1;
   margin-bottom: 0;
+  top:100%;
 }
 
 .autosuggestion-option .autosuggestion-icon {


### PR DESCRIPTION
### JIRA link
[TD-6339](https://hee-tis.atlassian.net/browse/TD-6339)

### Description
To fix an issue where other screen elements were appearing above the autosuggest menu, the z-index of the autosuggest menu has been increased from 1 to 20

### Screenshots
<img width="207" height="212" alt="image" src="https://github.com/user-attachments/assets/eb07b8d2-3f09-4c22-b2ab-5498efa30b45" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6339]: https://hee-tis.atlassian.net/browse/TD-6339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ