### PR TITLE
Hide image elements in Questionnaire plugin report section

### DIFF
--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1746,6 +1746,6 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 /* QUESTIONNAIRE PLUGIN HIDE GRAPHS IN FEEDBACK SECTION
 /* ---------------------------------------------------------------------------------- */
 
-.mod_questionnaire_reportpage.generalbox .box canvas {
+.mod_questionnaire_reportpage.generalbox #cvs2 {
     display: none;
 }

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -1740,3 +1740,12 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
 #page-course-management #page-content .custom-control-input:checked ~ .custom-control-label::after {
   background-color: initial;
 }
+
+
+/* ---------------------------------------------------------------------------------- */
+/* QUESTIONNAIRE PLUGIN HIDE GRAPHS IN FEEDBACK SECTION
+/* ---------------------------------------------------------------------------------- */
+
+.mod_questionnaire_reportpage.generalbox .box canvas {
+    display: none;
+}


### PR DESCRIPTION
### JIRA link
[TD-6658](https://hee-tis.atlassian.net/browse/TD-6658)

### Description
I have added SCSS to remove the graph elements that are displayed with HTML Canvas in the report section of the Questionnaire (3rd party plugin functionality)

I note when tested with Wave there are 17 errors - related to the plugin content.

### Screenshots
<img width="823" height="437" alt="image" src="https://github.com/user-attachments/assets/ec97d261-2044-4694-b38d-d93efae144c1" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6658]: https://hee-tis.atlassian.net/browse/TD-6658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ