### PR TITLE
Fix scrolling issue on grade report and remove icons

### DIFF
--- a/scss/components/_grade-report.scss
+++ b/scss/components/_grade-report.scss
@@ -1,0 +1,44 @@
+/* Prevent the grade report expanding outside the page */
+#page-grade-report-grader-index .gradeparent {
+    overflow-x: auto !important;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+}
+
+#page-grade-report-grader-index #user-grades {
+    width: max-content !important;
+    min-width: 100%;
+}
+
+
+/* Add a little breathing space for the sorting arrow on the name column */
+#page-grade-report-grader-index #studentheader .arrow_link,
+#page-grade-report-grader-index #studentheader .moodle-actionmenu {
+    margin: 0 8px; /* Just a tiny bit of horizontal space */
+}
+
+/* Remove activity icons from the Grader Report headers */
+#page-grade-report-grader-index .gradereport-grader-table .itemicon {
+    display: none !important;
+}
+
+
+/* Fix wrapping issue of header text. When wrapping the next line wasn't aligned to match the text above */
+
+/* Ensure header text link uses the full available width */
+#page-grade-report-grader-index .gradereport-grader-table .gradeitemheader {
+    display: block !important;
+    text-indent: 0 !important;
+    padding-left: 0 !important;
+    margin-left: 0 !important;
+}
+
+/* Force the flex container to allow the text to wrap to the far left */
+#page-grade-report-grader-index .gradereport-grader-table .d-flex.flex-grow-1 {
+    display: block !important; /* Overrides d-flex to let text wrap naturally */
+}
+
+/* Ensure the text itself is left-aligned */
+#page-grade-report-grader-index .gradereport-grader-table th {
+    text-align: left !important;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -61,3 +61,4 @@ $btn-secondary-border: core.nhsuk-colour("dark-blue");
 @import "components/notifications";
 @import "components/breadcrumbs";
 @import "components/utilities";
+@import "components/grade-report";


### PR DESCRIPTION
### JIRA link
[TD-6749](https://hee-tis.atlassian.net/browse/TD-6749)

### Description
The main change was to prevent the grade report table extending off the screen resulting in the page being able to moved horizontally. The change has implemented an internal scroll bar so the report can scroll horizontally without the page moving left or right.

In addition to this, the little icons next to the header titles were removed. These icons had been removed elsewhere in the theme and don't add any meaningful information. If these titles wrapped, the text on subsequent lines now aligns to the left with the text above.

One other minor tweak was to give a little bit of breathing space between the First name / Last name title and the sorting arrow icon.

### Screenshots
<img width="1248" height="647" alt="image" src="https://github.com/user-attachments/assets/65cf58bc-38c6-4a89-a47e-2de567a7348a" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6749]: https://hee-tis.atlassian.net/browse/TD-6749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ