### PR TITLE
Text colour accessibility fixes

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -30,10 +30,6 @@
   }
 }
 
-.bg-secondary {
-  color: core.$nhsuk-reverse-button-text-color !important;
-}
-
 .btn {
   &.btn-secondary,
   &.btn-outline-secondary {
@@ -42,7 +38,7 @@
     box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
 
     &:visited {
-      color: core.$nhsuk-reverse-button-color;
+      color: #005eb8 !important;
     }
   }
 }
@@ -100,4 +96,9 @@
   outline: 4px solid #ffeb3b !important;
   outline-offset: 0 !important;
   text-decoration: none !important;
+}
+
+/* Apply NHSUK Frontend secondary button styles to Bulk enable button on course management page */
+button.bulkEnable {
+  @extend .nhsuk-button--secondary;
 }

--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -77,3 +77,9 @@ label input[type=checkbox] {
     }
   }
 }
+
+/* Ensure accessible text colour in the select boxes initial text that appears on a dark grey? */
+select .bg-secondary,
+[role="option"].bg-secondary {
+  color: #fff !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-6817](https://hee-tis.atlassian.net/browse/TD-6817)

### Description
The visited state of the buttons was appearing with white text which was not accessible.
Also there was an issue with select dropdowns where it initially appears with a text colour on a grey background that is not accessible. I have changed this text colour to white.

### Screenshots
Grab showing the Exit Activity button after having visited it previously. The text is now fully accessible.
<img width="778" height="250" alt="image" src="https://github.com/user-attachments/assets/082ced88-27fc-493d-9605-73c2675f5db4" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6817]: https://hee-tis.atlassian.net/browse/TD-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ