### PR TITLE
Expander button icon disappearing when clicking on the section headings on moodle courses

### DIFF
--- a/scss/components/_expander.scss
+++ b/scss/components/_expander.scss
@@ -58,8 +58,3 @@
     padding-left: 0.5rem;
   }
 }
-
-.section-item .nhsuk-expander .nhsuk-details__summary:focus .nhsuk-details__summary-text:before,
-.section-item .nhsuk-expander[open] .nhsuk-details__summary:focus .nhsuk-details__summary-text::before {
-  background-color: transparent;
-}


### PR DESCRIPTION
### JIRA link
[TD-6831](https://hee-tis.atlassian.net/browse/TD-6831)

### Description
The NHSUK Frontend style expanders (Details component) had an issue where when selected and gaining focus the icon was appearing transparent hence not visible. I have removed the SCSS that was causing this. Not sure why this SCSS was there so thorough testing recommended in case it was needed elsewhere. I am fixing an issue raised on the course page

### Screenshots

Before the fix
<img width="661" height="437" alt="image" src="https://github.com/user-attachments/assets/2c8551b7-9062-4145-a9ec-d6dba9a54a74" />

With the fix

<img width="714" height="388" alt="image" src="https://github.com/user-attachments/assets/59bfd7a3-7841-42db-aabe-b3ef627549b6" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6831]: https://hee-tis.atlassian.net/browse/TD-6831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ