### PR TITLE
Fix alignment issue with title and breadcrumbs on permissions page

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -221,3 +221,9 @@ body.pagelayout-report #page-wrapper #page .main-inner {
   padding-left: 3.5rem;
   padding-right: 3.5rem;
 }
+
+/* remove the max-width restriction and allow the breadcrumb and title */
+/*  to align left with the rest of the content                         */
+.path-admin.path-admin-roles:not(.format-site) .header-maxwidth {
+  max-width: unset !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-6820](https://hee-tis.atlassian.net/browse/TD-6820)

### Description
On the permissions page, the breadcrumbs and title were not left aligned due to a max width setting. I have resolved this by removing this max width using unset.

### Screenshots
Before fix
<img width="1024" height="574" alt="image" src="https://github.com/user-attachments/assets/0e3bd9ef-5346-42d5-a8aa-230b8720511a" />

After fix
<img width="1314" height="429" alt="image" src="https://github.com/user-attachments/assets/e2a1d20f-cbd5-4d57-b540-6ea5d03d4cbc" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6820]: https://hee-tis.atlassian.net/browse/TD-6820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ