### PR TITLE
Make Full Screen and Exit Full Screen button accessible with tab key

### DIFF
--- a/javascript/scorm-fullscreen.js.php
+++ b/javascript/scorm-fullscreen.js.php
@@ -157,6 +157,8 @@ document.addEventListener('DOMContentLoaded', function () {
         fullScreenButton.style.marginRight = '10px';
         fullScreenButton.style.wordSpacing = 'normal';
         fullScreenButton.id = 'scorm-fullscreen-button';
+        fullScreenButton.setAttribute('href', 'javascript:void(0)'); 
+        fullScreenButton.setAttribute('role', 'button'); 
 
         // Create the white box container for fullscreen buttons
         const fullscreenButtonContainer = document.createElement('div');
@@ -182,6 +184,8 @@ document.addEventListener('DOMContentLoaded', function () {
         exitFullscreenButton.textContent = 'Exit full screen';
         exitFullscreenButton.style.wordSpacing = 'normal';
         exitFullscreenButton.id = 'scorm-exit-fullscreen-button';
+        exitFullscreenButton.setAttribute('href', 'javascript:void(0)'); 
+        exitFullscreenButton.setAttribute('role', 'button'); 
 
         // Create custom "Exit activity" button (shown in fullscreen)
         const exitActivityButton = document.createElement('a');
@@ -191,7 +195,6 @@ document.addEventListener('DOMContentLoaded', function () {
         exitActivityButton.style.wordSpacing = 'normal';
         exitActivityButton.id = 'scorm-exit-activity-button';
         exitActivityButton.innerHTML = svgIconCode + 'Exit activity';
-
 
         // Append the exit buttons to the white box container
         fullscreenButtonContainer.appendChild(exitFullscreenButton);
@@ -286,7 +289,8 @@ document.addEventListener('DOMContentLoaded', function () {
         };
         
         
-        fullScreenButton.addEventListener('click', function () {
+        fullScreenButton.addEventListener('click', function (e) {
+            e.preventDefault(); 
             if (!isFullScreen) { // Currently not in fullscreen
                 if (isMobile()) {
                     enterSimulatedFullscreen();
@@ -301,7 +305,8 @@ document.addEventListener('DOMContentLoaded', function () {
         });
 
         // Event listener for the "Exit full screen" button within the white box
-        exitFullscreenButton.addEventListener('click', function () {
+        exitFullscreenButton.addEventListener('click', function (e) {
+            e.preventDefault();
              if (fullscreenMode === "native") {
                 exitNativeFullscreen();
             } else if (fullscreenMode === "simulated") {


### PR DESCRIPTION
### JIRA link
[TD-6819](https://hee-tis.atlassian.net/browse/TD-6819)

### Description
The Full Screen button and Exit Full Screen button were not accessible to tab to using the keyboard. I have added attributes and amended the eventListener to resolve this.

### Screenshots
Nothing to see

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6819]: https://hee-tis.atlassian.net/browse/TD-6819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ