### PR TITLE
Prevent background scroll when permissions popup displayed

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -1,4 +1,28 @@
 
+// Fix for Moodle Dialogue Scroll-Lock Issue
+// Prevents background scrolling when Permissions/SCORM popups are open.
+html.lockscroll {
+    overflow: hidden !important;
+    position: relative; 
+}
+
+body.lockscroll {
+    overflow: hidden !important;
+    height: 100vh !important;
+    position: fixed;
+    width: 100%;
+}
+
+// Ensure YUI3/Legacy Moodle dialogues stay centered in viewport
+.moodle-dialogue-base .moodle-dialogue {
+    position: fixed !important;
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    z-index: 1050 !important; 
+}
+
+
 /**
  * Page and headings
  */


### PR DESCRIPTION
### JIRA link
[TD-6826](https://hee-tis.atlassian.net/browse/TD-6826)

### Description
On the permissions screen for a SCORM resource for example, selecting the plus sign opens a popup type menu.
This popup menu should appear in the centre and the screen behind should not be scrollable.

I have added SCSS to _layout.scss to ensure the background remains fixed and popup is central.

### Screenshots
<img width="865" height="482" alt="image" src="https://github.com/user-attachments/assets/38e126d3-180f-4d0d-aa40-bebf459a3f1f" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6826]: https://hee-tis.atlassian.net/browse/TD-6826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ