### PR TITLE
Bugfix/td 6828 moodle reports page for scorm resource accessibility issue when download button active and in focus

### DIFF
--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -166,6 +166,16 @@ a.nav-link:active {
   text-decoration: none !important;
 }
 
+/* Apply the same NHS focus style to standard Select menus */
+select.form-control:focus,
+.custom-select:focus {
+    border: 2px solid #212b32 !important;
+    box-shadow: inset 0 0 0 2px #212b32 !important;
+    outline: 4px solid #ffeb3b !important;
+    outline-offset: 0 !important;
+    color: #212b32 !important;
+}
+
 .simplesearchform .form-control:focus {
   color: #212b32;
   background-color: #fff;

--- a/scss/components/_dropdown.scss
+++ b/scss/components/_dropdown.scss
@@ -36,3 +36,29 @@
     left: auto !important;
     border-radius: 0 !important;            /* reset NHS radius */
 }
+
+/* ==============================
+    State Management (Focus & Open)
+   ============================== */
+
+/* Fix for SCORM Download Dropdown and other btn-secondary toggles 
+   Ensures text remains visible when the dropdown is open (.show) or focused */
+
+/* ==============================
+    NHS Styled State Management
+   ============================== */
+
+/* Target the dropdown when it's actually OPEN (.show) */
+.show > .btn-secondary.dropdown-toggle,
+.show > .btn-outline-secondary.dropdown-toggle {
+    /* Use the NHS Dark Grey for text to ensure visibility */
+    color: #212b32 !important;
+    
+    /* Use a light background so the dark text stands out */
+    background-color: #ffffff !important;   /* Pure white to match Selects */
+    
+    /* Keep the NHS Focus treatment consistent */
+    border: 2px solid #212b32 !important;
+    outline: 4px solid #ffeb3b !important;
+    outline-offset: 0 !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-6828](https://hee-tis.atlassian.net/browse/TD-6828)

### Description
On the SCORM reports page, there is a Download dropdown widget on the top right. There was an accessibility issue whereby if you used the keyboard to tab to this and then pressed spacebar, the text was displaying in white on a white background. This has been resolved.

At the same time I have applied NHS style focus styling to the select dropdown elements for consistency

### Screenshots
This is how it was looking prior to the fix

<img width="401" height="167" alt="image" src="https://github.com/user-attachments/assets/3fb6fe04-c7ea-4168-8521-0dd20c74651b" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6828]: https://hee-tis.atlassian.net/browse/TD-6828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ