### PR TITLE
Remove previous and next course navigation

### DIFF
--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -1,3 +1,10 @@
 .nhsuk-pagination__link .nhsuk-icon {
   fill: core.nhsuk-colour("blue");
 }
+
+/* hide course pagination */
+/* Global removal of redundant course/activity navigation */
+.path-course-view .nhsuk-pagination,
+.path-mod .nhsuk-pagination {
+    display: none !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-6844](https://hee-tis.atlassian.net/browse/TD-6844)

### Description
Global removal of the Previous and Next links that appear on course pages. This is a CSS solution.

### Screenshots
n/a

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6844]: https://hee-tis.atlassian.net/browse/TD-6844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ