### PR TITLE
Hide second back to course link

### DIFF
--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -1,0 +1,6 @@
+
+/* hide the second "back to course" link in scorm */
+.path-mod-scorm .course-content-footer {
+    position: absolute !important;
+    left: -9999px;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -61,3 +61,4 @@ $btn-secondary-border: core.nhsuk-colour("dark-blue");
 @import "components/notifications";
 @import "components/utilities";
 @import "components/grade-report";
+@import "components/navigation";


### PR DESCRIPTION
### JIRA link
[TD-6602](https://hee-tis.atlassian.net/browse/TD-6602)

### Description
Two instances of the "Back to course" link appear, one at the top and one at the bottom. This update removes the button one using CSS.

### Screenshots
<img width="470" height="245" alt="image" src="https://github.com/user-attachments/assets/f7a87929-fa05-4692-8d15-f42a8ffde09e" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6602]: https://hee-tis.atlassian.net/browse/TD-6602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ