### PR TITLE
Refactor to hide link on all page types

### DIFF
--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -1,6 +1,5 @@
-
-/* hide the second "back to course" link in scorm */
-.path-mod-scorm .course-content-footer {
-    position: absolute !important;
-    left: -9999px;
+/* hide the second "back to course" link on all page types */
+/* This replaces the previous solution that hid the link only on SCORM page types  */
+.course-content-footer a[href*="view.php?id="] {
+    display: none !important;
 }


### PR DESCRIPTION
### JIRA link
[TD-6863](https://hee-tis.atlassian.net/browse/TD-6863)

### Description
Refactor the code to hide the second instance of the Back to course link. The previous code only hid this on SCORM page types.

This hides them on app page types. It has an added check to cater for the scenario there was ever any other links within this container.

### Screenshots
<img width="734" height="428" alt="image" src="https://github.com/user-attachments/assets/ffc5ec6e-9248-4cbb-979c-95a27b1f1789" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6863]: https://hee-tis.atlassian.net/browse/TD-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ