### PR TITLE
Updates to align LHS menu icons and lock icons on RHS

### DIFF
--- a/scss/components/_expander.scss
+++ b/scss/components/_expander.scss
@@ -47,7 +47,7 @@
 .nhsuk-details.nhsuk-expander .section_link,
 .nhsuk-details.nhsuk-expander .summarytext,
 .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
-  padding-left: 0.75rem;
+  padding-left: 2rem;
 }
 
 @media (max-width: 37.49em) {
@@ -55,6 +55,6 @@
   .nhsuk-details.nhsuk-expander .section_link,
   .nhsuk-details.nhsuk-expander .summarytext,
   .course-content ul.topics li.section .nhsuk-expander .nhsuk-details__text.content {
-    padding-left: 0.5rem;
+    padding-left: 1.5rem;
   }
 }

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -19,7 +19,7 @@
     margin-top: 0;   
 }
 
-.drawercontent .courseindex .icon.fa {
+.drawercontent .courseindex .icon.fa-circle, .drawercontent .courseindex .icon.fa {
 	display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -31,8 +31,16 @@
     align-self: center;
 }
 
-.drawercontent .courseindex .courseindex-item .courseindex-locked {    
-    display: inline-flex;
+/* Course index lock icons: visible only for actually locked sections */
+.drawercontent .courseindex .courseindex-item .courseindex-locked {
+    display: none; /* hide by default for all sections */
+    align-items: center;
+    align-self: center;
+}
+
+/* Show lock only for sections with restrictions */
+.drawercontent .courseindex .courseindex-item.restrictions .courseindex-locked {
+    display: inline-flex; /* show visually */
     align-items: center;
     align-self: center;
 }

--- a/scss/components/_icons.scss
+++ b/scss/components/_icons.scss
@@ -1,0 +1,38 @@
+/* ==========================================================================
+// Lock icon alignment on the details expander
+// ========================================================================== */
+.nhsuk-details.nhsuk-expander .icon.fa-lock {
+	font-size: 16px;
+    width: 1.6em;
+    height: 1.6em;   
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-bottom: 4px;
+}
+
+/* =========================================================================
+// Left hand side menu icons alignment
+.. ========================================================================= */
+
+.drawercontent .courseindex .completioninfo .icon {  
+    margin-top: 0;   
+}
+
+.drawercontent .courseindex .icon.fa {
+	display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.drawercontent .courseindex .completioninfo {
+    display: inline-flex;
+    align-items: center;
+    align-self: center;
+}
+
+.drawercontent .courseindex .courseindex-item .courseindex-locked {    
+    display: inline-flex;
+    align-items: center;
+    align-self: center;
+}

--- a/scss/nhse.scss
+++ b/scss/nhse.scss
@@ -62,3 +62,4 @@ $btn-secondary-border: core.nhsuk-colour("dark-blue");
 @import "components/utilities";
 @import "components/grade-report";
 @import "components/navigation";
+@import "components/icons";

--- a/templates/core_courseformat/local/content/section/content.mustache
+++ b/templates/core_courseformat/local/content/section/content.mustache
@@ -96,23 +96,26 @@
     >
         <summary class="nhsuk-details__summary">
             <span class="nhsuk-details__summary-text">
+            <div class="d-flex align-items-center position-relative flex-grow-1">
                 {{#singleheader}}
                     {{$ core_courseformat/local/content/section/header }}
                         {{> core_courseformat/local/content/section/header }}
                     {{/ core_courseformat/local/content/section/header }}
                 {{/singleheader}}
-                {{#header}}
+             
+                {{^singleheader}}
+                  {{#header}}
                     {{$ core_courseformat/local/content/section/header }}
                         {{> core_courseformat/local/content/section/header }}
                     {{/ core_courseformat/local/content/section/header }}
-                {{/header}}
-                {{^singleheader}}
+                    {{/header}}
                     {{#restrictionlock}}
-                        <div class="align-self-center ms-2">
+                         <span class="ms-2">
                             {{#pix}}t/unlock, core{{/pix}}
-                        </div>
+                        </span>
                     {{/restrictionlock}}
                 {{/singleheader}}
+               </div>
                 <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
                     {{$ core_courseformat/local/content/section/badges }}
                         {{> core_courseformat/local/content/section/badges }}
@@ -192,23 +195,26 @@
         data-id="{{id}}"
         data-number="{{num}}"
     >
+     <div class="d-flex align-items-center position-relative flex-grow-1">
         {{#singleheader}}
             {{$ core_courseformat/local/content/section/header }}
                 {{> core_courseformat/local/content/section/header }}
             {{/ core_courseformat/local/content/section/header }}
         {{/singleheader}}
-        {{#header}}
+       
+        {{^singleheader}}
+         {{#header}}
             {{$ core_courseformat/local/content/section/header }}
                 {{> core_courseformat/local/content/section/header }}
             {{/ core_courseformat/local/content/section/header }}
         {{/header}}
-        {{^singleheader}}
             {{#restrictionlock}}
                 <div class="align-self-center ms-2">
                     {{#pix}}t/unlock, core{{/pix}}
                 </div>
             {{/restrictionlock}}
         {{/singleheader}}
+        </div>
         <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
             {{$ core_courseformat/local/content/section/badges }}
                 {{> core_courseformat/local/content/section/badges }}

--- a/templates/core_courseformat/local/content/section/content.mustache
+++ b/templates/core_courseformat/local/content/section/content.mustache
@@ -108,12 +108,20 @@
                     {{$ core_courseformat/local/content/section/header }}
                         {{> core_courseformat/local/content/section/header }}
                     {{/ core_courseformat/local/content/section/header }}
-                    {{/header}}
+                    {{/header}}                   
+                     <!-- General section lock -->
                     {{#restrictionlock}}
-                         <span class="ms-2">
-                            {{#pix}}t/unlock, core{{/pix}}
+                        <span class="ms-2">
+                            {{#pix}}t/locked, core{{/pix}}
                         </span>
                     {{/restrictionlock}}
+
+                    <!-- Other sections lock -->
+                    {{#availability.isrestricted}}
+                        <span class="ms-2">
+                            {{#pix}}t/locked, core{{/pix}}
+                        </span>
+                    {{/availability.isrestricted}}
                 {{/singleheader}}
                </div>
                 <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
@@ -167,9 +175,7 @@
                     {{/ core_courseformat/local/content/section/summary }}
                 {{/summary}}
                 {{#availability}}
-                    {{$ core_courseformat/local/content/section/availability }}
                         {{> core_courseformat/local/content/section/availability }}
-                    {{/ core_courseformat/local/content/section/availability }}
                 {{/availability}}
             </div>
             {{#cmsummary}}
@@ -195,26 +201,19 @@
         data-id="{{id}}"
         data-number="{{num}}"
     >
-     <div class="d-flex align-items-center position-relative flex-grow-1">
+    
         {{#singleheader}}
             {{$ core_courseformat/local/content/section/header }}
                 {{> core_courseformat/local/content/section/header }}
             {{/ core_courseformat/local/content/section/header }}
         {{/singleheader}}
        
-        {{^singleheader}}
          {{#header}}
             {{$ core_courseformat/local/content/section/header }}
                 {{> core_courseformat/local/content/section/header }}
             {{/ core_courseformat/local/content/section/header }}
         {{/header}}
-            {{#restrictionlock}}
-                <div class="align-self-center ms-2">
-                    {{#pix}}t/unlock, core{{/pix}}
-                </div>
-            {{/restrictionlock}}
-        {{/singleheader}}
-        </div>
+      
         <div data-region="sectionbadges" class="sectionbadges d-flex align-items-center">
             {{$ core_courseformat/local/content/section/badges }}
                 {{> core_courseformat/local/content/section/badges }}


### PR DESCRIPTION
### JIRA link
[TD-6974](https://hee-tis.atlassian.net/browse/TD-6974)

### Description
The lock icons on the RHS content area were displaying badly aligned on the line below the section title. This update has updated the mustache file to move these lock icons onto the same line as the title.

This update also adds SCSS to fix the alignment of the lock icons on the LHS menu. They were displaying too high compared to the associated titles. Also this SCSS improved the alignment of the circle (completion) icons too.

### Screenshots
<img width="750" height="466" alt="image" src="https://github.com/user-attachments/assets/c75ca888-ec17-4beb-90d2-ccd5a26d9325" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6974]: https://hee-tis.atlassian.net/browse/TD-6974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ