### PR TITLE
Additions for logged in as other user banner

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -60,6 +60,15 @@ class core_renderer extends \theme_boost\output\core_renderer
         $context = new \stdClass();
         $context->customnavigation = []; // Default to empty array in case of API issues
         $context->notification_count = 0; // Initialize notification count for the template
+        // Add impersonation info if logged in as another user
+        $context->loggedinasotheruser = \core\session\manager::is_loggedinas();
+
+        if ($context->loggedinasotheruser) {
+            // $USER is the impersonated user
+            $context->impersonatedusername = fullname($USER);
+        } else {
+            $context->impersonatedusername = '';
+        }
 
         // Fetch token for current user
         $token = null; // Initialize to null
@@ -306,13 +315,8 @@ class core_renderer extends \theme_boost\output\core_renderer
                  // $context->notification_count remains 0 on error
              }
         }
-
-        // NEW: Require your autosuggest JavaScript module
-        $this->page->requires->js_call_amd('theme_nhse/autosuggest', 'init');
-
-        // You can remove this for now, or keep it, it won't hurt
-        // $this->page->requires->js_init_call('M.cfg.userid = ' . $USER->id . ';');
-
+        
+        $this->page->requires->js_call_amd('theme_nhse/autosuggest', 'init');        
         
         return $context; 
     }

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -1131,4 +1131,31 @@ button.nhsuk-header__menu-toggle.nav-link:focus {
 }
 
 
+/* Admin logged in as another user banner  */
+.nhsuk-banner--admin-login {
+    background-color: #ffeb3b;     // NHS yellow
+    color: #212b32;                  // Dark text    
+    padding: 12px 16px;
+    width: 100%;
+    box-sizing: border-box;
 
+    /* Make the inner container full width and flex for right alignment */
+    .nhsuk-width-container {
+        width: 100%;
+        display: flex;
+        justify-content: flex-end;  // right-align text
+        align-items: center;
+        padding-right: 1rem;                
+    }
+
+    /* Style the text */
+    .nhsuk-banner__content {
+        margin: 0;
+        font-size: 1.25rem;
+    }
+
+    /* Optional: make the strong name a little bolder */
+    .nhsuk-banner__content strong {
+        font-weight: 700;
+    }
+}

--- a/templates/header.mustache
+++ b/templates/header.mustache
@@ -54,6 +54,17 @@
         ]
     }
 }}
+
+
+{{#loggedinasotheruser}}
+<div class="nhsuk-banner nhsuk-banner--admin-login" role="status" aria-live="polite">
+    <div class="nhsuk-width-container">
+         <p class="nhsuk-banner__content nhsuk-banner__content--right">
+            ⚠ You are logged in as <strong>{{impersonatedusername}}</strong>           
+        </p>
+    </div>
+</div>
+{{/loggedinasotheruser}}
 <header class="nhsuk-header {{#navbarstyle}}nhsuk-header--{{navbarstyle}}{{/navbarstyle}}{{^navbarstyle}}nhsuk-header--default{{/navbarstyle}}"
         role="banner"
         data-module="nhsuk-header">


### PR DESCRIPTION
### JIRA link
[TD-6822](https://hee-tis.atlassian.net/browse/TD-6822)

### Description
Addition of a banner when the admin is logged in as another user. This banner highlights this and shows them the name of the user they are logged in as.

### Screenshots
<img width="1467" height="353" alt="image" src="https://github.com/user-attachments/assets/3c07f2c0-714a-4e64-95d4-dab87e837d00" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6822]: https://hee-tis.atlassian.net/browse/TD-6822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ