### PR TITLE
Reduce vertical whitespace on delete course notice

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -1,25 +1,24 @@
-
 // Fix for Moodle Dialogue Scroll-Lock Issue
 // Prevents background scrolling when Permissions/SCORM popups are open.
 html.lockscroll {
-    overflow: hidden !important;
-    position: relative; 
+  overflow: hidden !important;
+  position: relative;
 }
 
 body.lockscroll {
-    overflow: hidden !important;
-    height: 100vh !important;
-    position: fixed;
-    width: 100%;
+  overflow: hidden !important;
+  height: 100vh !important;
+  position: fixed;
+  width: 100%;
 }
 
 // Ensure YUI3/Legacy Moodle dialogues stay centered in viewport
 .moodle-dialogue-base .moodle-dialogue {
-    position: fixed !important;
-    top: 50% !important;
-    left: 50% !important;
-    transform: translate(-50%, -50%) !important;
-    z-index: 1050 !important; 
+  position: fixed !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  z-index: 1050 !important;
 }
 
 
@@ -60,6 +59,7 @@ body.lockscroll {
   display: flex;
   flex-direction: column;
 }
+
 #page {
   flex: 1 0 auto;
   display: flex;
@@ -178,7 +178,7 @@ body.lockscroll {
   body.limitedwidth.pagelayout-mycourses #page.drawers .main-inner,
   body.pagelayout-incourse #page.drawers .main-inner,
   body.pagelayout-admin #page.drawers .main-inner,
-  body.pagelayout-report #page.drawers .main-inner {    
+  body.pagelayout-report #page.drawers .main-inner {
     max-width: unset;
   }
 }
@@ -264,4 +264,18 @@ body.pagelayout-report #page-wrapper #page .main-inner {
 /*  to align left with the rest of the content                         */
 .path-admin.path-admin-roles:not(.format-site) .header-maxwidth {
   max-width: unset !important;
+}
+
+/* remove the 100% height on in-page "modal" */
+/* also reduce vertical padding generally */
+#page-course-delete #notice {
+  height: auto;
+
+  #modal-content.py-3 {
+    padding: 0 !important;
+  }
+
+  .btn {
+    margin-bottom: 0;
+  }
 }


### PR DESCRIPTION
### JIRA link
[TD-6902](https://hee-tis.atlassian.net/browse/TD-6902)

### Description
Overridden vertical padding for delete course page only

### Screenshots
<img width="1782" height="1125" alt="image" src="https://github.com/user-attachments/assets/8258171f-33d6-4466-8727-064246b567c2" />

<img width="406" height="904" alt="image" src="https://github.com/user-attachments/assets/fec1ab88-99c5-460b-804a-7793a2b65379" />



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6902]: https://hee-tis.atlassian.net/browse/TD-6902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ