### PR TITLE
Bugfix/td 7001 moodle account elements in header UI issue

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -361,8 +361,7 @@ button.nhsuk-header__menu-toggle.nav-link:focus {
   background-color: unset;
 }
 
-.nhsuk-header__account-item {
-  padding-bottom:0 !important;
+.nhsuk-header__account-item {  
   flex-grow: 0;
 }
 
@@ -509,10 +508,10 @@ button.nhsuk-header__menu-toggle.nav-link:focus {
 .nhsuk-header__edit-switch-item label {
     display: flex;
     align-items: center;
-    padding: 8px 12px;   /* Large hit area */
-    margin: -8px -12px;  /* Visual correction */
-    cursor: pointer;     /* Makes the whole label feel like a link */
-    padding-right:4px;
+    cursor: pointer;    
+    /* Top: 8px | Right: 4px | Bottom: 0 | Left: 12px */
+    padding: 8px 4px 0 12px;       
+    margin: -8px -12px;
 }
 
 
@@ -1130,5 +1129,8 @@ button.nhsuk-header__menu-toggle.nav-link:focus {
   border-top: none !important;
 }
 
+.nhsuk-header__account-item {
+  padding: 8px 12px;
+}
 
 


### PR DESCRIPTION
### JIRA link
[_TD-7001_](https://hee-tis.atlassian.net/browse/TD-7001)

### Description
Fixed an issue where when the Edit mode button was not included in the header the height of the "My account" and "Logout" buttons was too short causing these buttons not to align nicely with the search box

### Screenshots
<img width="748" height="154" alt="image" src="https://github.com/user-attachments/assets/af02c0bc-effd-49b4-91be-1325039bd9e6" />

<img width="755" height="72" alt="image" src="https://github.com/user-attachments/assets/e3b01000-2ce7-441d-88e0-601015746aa0" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
