### PR TITLE
Prevent footer overlap issue

### DIFF
--- a/scss/components/_scorm-fullscreen.scss
+++ b/scss/components/_scorm-fullscreen.scss
@@ -87,3 +87,9 @@ body.simulated-fullscreen {
     }
 }
 
+/* Prevent inline SCORM resource overlapping footer */
+#page-mod-scorm-player #scormpage,
+#page-mod-scorm-player #tocbox,
+#page-mod-scorm-player #scormpage #scorm_content {
+  height: auto !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-7011](https://hee-tis.atlassian.net/browse/TD-7011)

### Description
Some SCORM content was overlapping the footer so have added CSS to resolve this.

### Screenshots
<img width="651" height="403" alt="image" src="https://github.com/user-attachments/assets/b0a2c42e-9b8c-46a2-b5b5-2845de77829d" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7011]: https://hee-tis.atlassian.net/browse/TD-7011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ