### PR TITLE
padding fix for my courses page

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -279,3 +279,9 @@ body.pagelayout-report #page-wrapper #page .main-inner {
     margin-bottom: 0;
   }
 }
+
+.page-mycourses .drawers .block_myoverview > .card-body.p-3 {
+  padding-top: 1.25rem !important;
+  padding-left: 1.25rem !important;
+  padding-right: 1.25rem !important;
+}


### PR DESCRIPTION
### JIRA link
[TD-6910](https://hee-tis.atlassian.net/browse/TD-6910)

### Description
Overwitten !important css rules that broke padding 

### Screenshots
<img width="837" height="901" alt="image" src="https://github.com/user-attachments/assets/53b04098-90bf-4c94-8aa0-71bdcc615d63" />
<img width="396" height="867" alt="image" src="https://github.com/user-attachments/assets/62a266b3-93c9-41ca-8aa7-da7e5fa80e46" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6910]: https://hee-tis.atlassian.net/browse/TD-6910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ