### PR TITLE
Fix alignment issue by removing max width

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -263,7 +263,14 @@ body.pagelayout-report #page-wrapper #page .main-inner {
 /* remove the max-width restriction and allow the breadcrumb and title */
 /*  to align left with the rest of the content                         */
 .path-admin.path-admin-roles:not(.format-site) .header-maxwidth {
-  max-width: unset !important;
+  max-width: none !important;
+}
+
+/* Override the 830px restriction for Learning Plans and Admin Roles */
+.path-admin.path-admin-tool-lp .header-maxwidth,
+.path-admin.path-admin-roles:not(.format-site) .header-maxwidth,
+body.pagelayout-admin #page.drawers .main-inner header .header-maxwidth {
+    max-width: none !important;
 }
 
 /* remove the 100% height on in-page "modal" */


### PR DESCRIPTION
### JIRA link
[TD-7047](https://hee-tis.atlassian.net/browse/TD-7047)

### Description
Added SCSS to remove the max width setting on the header where the breadcrumb is contained on this page type (competencies and learning plan templates)

### Screenshots
Before
<img width="748" height="350" alt="image" src="https://github.com/user-attachments/assets/5fe765e9-9902-4d64-aa14-b8b5adb2cbfb" />

After
<img width="569" height="231" alt="image" src="https://github.com/user-attachments/assets/10957cc0-2b51-4c09-abcc-0de35db1a9b6" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7047]: https://hee-tis.atlassian.net/browse/TD-7047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ