### PR TITLE
update focus state override plus icon focus

### DIFF
--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -52,12 +52,16 @@ a:not([class]).focus,
 a:not([class]):focus,
 .activityinstance>a.focus,
 .activityinstance>a:focus {
-  outline: 4px solid core.nhsuk-colour("white");
-  color: core.nhsuk-colour("black");
-  background-color: core.nhsuk-colour("yellow");
-  box-shadow: 0 -2px core.nhsuk-colour("yellow"), 0 4px core.nhsuk-colour("black");
-  text-decoration: none;
+    background-color: core.nhsuk-colour("yellow");
+    box-shadow: 0 -2px core.nhsuk-colour("yellow"), 0 3px core.nhsuk-colour("black");
+    outline: 4px solid transparent;
+    text-decoration: none;
 }
+
+.btn.btn-icon:focus {
+    background-color: core.nhsuk-colour("yellow");
+}
+
 
 /* Removing style focus and adding nhsuk focus for left hand side menu button */
 .drawer-toggles .drawer-toggler .btn:focus {


### PR DESCRIPTION
### JIRA link
[TD-7026](https://hee-tis.atlassian.net/browse/TD-7026)

### Description
Updated focus override to more closely match NHS design system

### Screenshots
<img width="893" height="560" alt="image" src="https://github.com/user-attachments/assets/deaee224-3502-47f5-ad5b-a177eb3cdd5c" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7026]: https://hee-tis.atlassian.net/browse/TD-7026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ