### PR TITLE
Bugfix/td 7045 issue with the changing colour of dialog boxes appearing on permissions screen on moodle courses

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -17,8 +17,7 @@ body.lockscroll {
   position: fixed !important;
   top: 50% !important;
   left: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  // z-index: 1050 !important;
+  transform: translate(-50%, -50%) !important;  
 }
 
 

--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -18,7 +18,7 @@ body.lockscroll {
   top: 50% !important;
   left: 50% !important;
   transform: translate(-50%, -50%) !important;
-  z-index: 1050 !important;
+  // z-index: 1050 !important;
 }
 
 


### PR DESCRIPTION
### JIRA link
[TD-7045](https://hee-tis.atlassian.net/browse/TD-7045)

### Description
Remove a z-index setting that was previously set in another fix. This was causing an issue due to the mask that sits below the element with the z-index having its z-index set to increment. Removing the hard coded z-index lets Moodle set both dynamically so prevents the layering issue.

### Screenshots
<img width="593" height="346" alt="image" src="https://github.com/user-attachments/assets/49c4d8fd-46ab-416c-bbec-a63eb0113f18" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7045]: https://hee-tis.atlassian.net/browse/TD-7045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ