### PR TITLE
remove centre alignment of continuebutton class

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -291,3 +291,7 @@ body.pagelayout-admin #page.drawers .main-inner header .header-maxwidth {
   padding-left: 1.25rem !important;
   padding-right: 1.25rem !important;
 }
+
+.continuebutton {
+  text-align: unset;
+}


### PR DESCRIPTION
### JIRA link
[TD-7071](https://hee-tis.atlassian.net/browse/TD-7071)

### Description
Unset the centre align css for the button container

### Screenshots
<img width="1620" height="1032" alt="image" src="https://github.com/user-attachments/assets/86ceb29f-f6ea-47a8-893d-28383f23905e" />

<img width="564" height="1025" alt="image" src="https://github.com/user-attachments/assets/a55fd50c-f55e-49e1-96aa-0db7b8e1e84e" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7071]: https://hee-tis.atlassian.net/browse/TD-7071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ