### PR TITLE
add margin below main content first h2 tag

### DIFF
--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -17,7 +17,7 @@ body.lockscroll {
   position: fixed !important;
   top: 50% !important;
   left: 50% !important;
-  transform: translate(-50%, -50%) !important;  
+  transform: translate(-50%, -50%) !important;
 }
 
 
@@ -269,7 +269,7 @@ body.pagelayout-report #page-wrapper #page .main-inner {
 .path-admin.path-admin-tool-lp .header-maxwidth,
 .path-admin.path-admin-roles:not(.format-site) .header-maxwidth,
 body.pagelayout-admin #page.drawers .main-inner header .header-maxwidth {
-    max-width: none !important;
+  max-width: none !important;
 }
 
 /* remove the 100% height on in-page "modal" */
@@ -286,8 +286,12 @@ body.pagelayout-admin #page.drawers .main-inner header .header-maxwidth {
   }
 }
 
-.page-mycourses .drawers .block_myoverview > .card-body.p-3 {
+.page-mycourses .drawers .block_myoverview>.card-body.p-3 {
   padding-top: 1.25rem !important;
   padding-left: 1.25rem !important;
   padding-right: 1.25rem !important;
+}
+
+[role="main"] h2:first-of-type {
+  margin-bottom: 1rem;
 }


### PR DESCRIPTION
### JIRA link
[TD-7075](https://hee-tis.atlassian.net/browse/TD-7075)

### Description
Added 1rem margin below first H2 tag in divs with role="main" - should solve problem across a number of pages

formatting page corrected some minor whitespace issues.

### Screenshots
<img width="1156" height="1031" alt="image" src="https://github.com/user-attachments/assets/1d3737c3-20fa-43a9-9b83-3287906d508d" />

<img width="1169" height="1026" alt="image" src="https://github.com/user-attachments/assets/7f1ddea1-afbe-449f-a9fd-350d9ebfe62c" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7075]: https://hee-tis.atlassian.net/browse/TD-7075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ