### PR TITLE
Fix alignment of show options dropdown on the my courses list screen (7119) and Heading space on Restore course page

### DIFF
--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -83,3 +83,22 @@ select .bg-secondary,
 [role="option"].bg-secondary {
   color: #fff !important;
 }
+
+
+// ==========================================================================
+// BACKUP AND RESTORE PAGE OVERRIDES
+// ==========================================================================
+
+// Targets the restore and backup pages specifically
+#page-backup-restorefile, 
+#page-backup-backup {
+    // Adds breathing space below the heading
+    h3.mt-6 {
+        margin-bottom: 0.5rem !important; 
+    }
+
+    // Adds space below the description text (e.g Private backup files...)
+    .mb-3 {
+        margin-bottom: 1rem !important;
+    }
+}

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -8,3 +8,12 @@
 .path-mod .nhsuk-pagination {
     display: none !important;
 }
+
+// Fix for vertical alignment in Moodle pagination
+// Overrides global NHS button margins that push the dropdown out of alignment.
+[data-region="paging-control-container"] {
+    .btn, 
+    .page-link {
+        margin-bottom: 0 !important;
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-7119](https://hee-tis.atlassian.net/browse/TD-7119)
[TD-7118](https://hee-tis.atlassian.net/browse/TD-7118)
### Description
I have fixed an issue where the Show text was misaligned with the associated select list. 

I have also accidentally committed a fix for TD-7118 in this branch so this PR covers both.
TD-7118 issue was the need for breathing space below the titles on the Restore course screen. I have limited the fix to this page only to be on the safe side.

### Screenshots
TD-7119 grab
<img width="1087" height="362" alt="image" src="https://github.com/user-attachments/assets/c52cd729-a20b-4483-ba37-e085dfd591da" />



TD-7118 grab
<img width="1021" height="572" alt="image" src="https://github.com/user-attachments/assets/3397c6d3-ab67-44cf-ac77-823b55daa15c" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7119]: https://hee-tis.atlassian.net/browse/TD-7119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-7118]: https://hee-tis.atlassian.net/browse/TD-7118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ