### PR TITLE
Remove secondary back to course button from activity pages

### DIFF
--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -3,3 +3,11 @@
 .course-content-footer a[href*="view.php?id="] {
     display: none !important;
 }
+
+/* Hide the form-based "Back to course" button on activity pages */
+/* Scoped to .path-mod to avoid affecting admin/theme upgrade pages */
+body.path-mod .continuebutton {
+    form[action*="course/view.php"] {
+        display: none;
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-6863](https://hee-tis.atlassian.net/browse/TD-6863)

### Description
This removes a secondary "back to course" link that appears as a button on activity pages.

Screengrab shows only the first "back to course" link

### Screenshots
<img width="690" height="416" alt="image" src="https://github.com/user-attachments/assets/307ec36d-9e69-4614-aae6-f2d4628bd8f3" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6863]: https://hee-tis.atlassian.net/browse/TD-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ