### PR TITLE
Bugfix/td 7010 moodle theme button styling (bulk actions, message, primary, and secondary)

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -1,121 +1,158 @@
-/* ==========================================================================*/
-// BUTTON STYLES
-// ==========================================================================*/
+/* ==========================================================================
+   BUTTON STYLES
+   Mapping Moodle's native Bootstrap buttons to the NHSUK Design System
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. GLOBAL BASE BUTTONS
+   -------------------------------------------------------------------------- */
 
 .btn {
-  &:not(.btn-icon,
-    .btn-close,
-    .btn-link,
-    .btn-open,
-    .search-icon,
-    .navbar .dropdown-toggle,
-    .icon-no-margin) {
-    @extend .nhsuk-button--small;
-    box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
-  }
-
-  &.disabled {
-    @extend .nhsuk-button--disabled !optional;
-    box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
-  }
-
-  &.active,
-  &.visited {
-    @extend .nhsuk-button--reverse;
-    box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
-  }
-
-  &.text-primary {
-    color: $btn-secondary-text !important;
-  }
-}
-
-.btn {
-  &.btn-secondary,
-  &.btn-outline-secondary {
-    @extend .nhsuk-button--small;
-    @extend .nhsuk-button--secondary;
-    box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
-
-    &:visited {
-      color: #005eb8 !important;
+    &:not(.btn-icon, .btn-close, .btn-link, .btn-open, .search-icon, .navbar .dropdown-toggle, .icon-no-margin) {
+        @extend .nhsuk-button--small;
+        box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
     }
-  }
+
+    &.disabled {
+        @extend .nhsuk-button--disabled !optional;
+        box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
+    }
+
+    &.active,
+    &.visited {
+        @extend .nhsuk-button--reverse;
+        box-shadow: 0 2px 0 core.$nhsuk-button-shadow-colour;
+    }
+
+    &.text-primary {
+        color: $btn-secondary-text !important;
+    }
 }
 
-.btn-group>.btn:not(:first-child),
-.btn-group>.btn:not(:last-child):not(.dropdown-toggle),
-.btn-group>.btn-group:not(:first-child)>.btn,
-.btn-group>.btn-group:not(:last-child)>.btn {
-  border-top-left-radius: 4px !important;
-  border-top-right-radius: 4px !important;
-  border-bottom-left-radius: 4px !important;
-  border-bottom-right-radius: 4px !important;
+/* Fix Bootstrap button group radiuses */
+.btn-group > .btn:not(:first-child),
+.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group > .btn-group:not(:first-child) > .btn,
+.btn-group > .btn-group:not(:last-child) > .btn {
+    border-radius: 4px !important;
 }
 
-#navbuttons {
-  input[type="submit"] {
-    @extend .nhsuk-button--small;
-  }
+/* Remove unwanted Bootstrap shadows from dropdowns and pseudo-elements */
+.btn.dropdown-toggle,
+.btn-outline-secondary.dropdown-toggle {
+    box-shadow: none !important;
 }
 
 .nhsuk-button--secondary::after,
 .btn.btn-secondary::after,
 .btn.btn-outline-secondary::after,
 .nhsuk-button--secondary-solid::after {
-  box-shadow: none !important;
+    box-shadow: none !important;
 }
 
-// Prevent the buttons that have dropdowns having the drop shadow
-.btn.dropdown-toggle,
-.btn-outline-secondary.dropdown-toggle {
-  box-shadow: none !important;
+/* --------------------------------------------------------------------------
+   2. PRIMARY BUTTONS (NHS Green)
+   -------------------------------------------------------------------------- */
+
+.btn-primary {
+    background-color: core.nhsuk-colour("green") !important; 
+    box-shadow: 0 4px 0 core.nhsuk-shade(core.nhsuk-colour("green"), 20%) !important;    
+    border: none !important;
+    color: core.nhsuk-colour("white") !important;
+    font-weight: 600 !important;
+    padding: 8px 16px !important;
+    
+    &:hover {
+        background-color: core.nhsuk-shade(core.nhsuk-colour("green"), 20%) !important;
+        color: core.nhsuk-colour("white") !important;
+    }
+
+    &:focus {
+        background-color: core.nhsuk-colour("yellow") !important;
+        color: core.nhsuk-colour("black") !important;
+        box-shadow: 0 4px 0 core.nhsuk-colour("black") !important; 
+        outline: 3px solid transparent !important; 
+    }
 }
 
-.nhsuk-button--secondary:hover,
-.btn.btn-secondary:hover,
-.btn.btn-outline-secondary:hover,
-.nhsuk-button--secondary-solid:hover {
-  background-color: #d9e7f4 !important;
-  color: #212b32 !important; // or use NHSUK’s $nhsuk-text-color
+/* --------------------------------------------------------------------------
+   3. SECONDARY BUTTONS (Authentic NHS Blue)
+   -------------------------------------------------------------------------- */
+
+.btn-secondary,
+.btn-outline-secondary,
+.btn-outline-primary { 
+    background-color: transparent !important;
+    color: #005eb8 !important;
+    box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
+    border: none !important;
+    font-weight: normal !important;
+
+    &.dropdown-toggle {
+        box-shadow: none !important;
+    }
+
+    &:hover, 
+    &:active, 
+    &.active {
+        background-color: #d9e7f4 !important; 
+        color: #005eb8 !important;
+        box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important;
+    }
+
+    &:focus {
+        background-color: core.nhsuk-colour("yellow") !important;
+        color: core.nhsuk-colour("black") !important;
+        box-shadow: 0 4px 0 core.nhsuk-colour("black") !important;
+        outline: 3px solid transparent !important;
+    }
 }
 
-.btn-outline-secondary:not(:disabled):not(.disabled):active,
-.btn-outline-secondary:not(:disabled):not(.disabled).active,
-.show > .btn-outline-secondary.dropdown-toggle {
-    color: #212b32 !important; // or use NHSUK’s $nhsuk-text-color
+/* --------------------------------------------------------------------------
+   4. CONTEXT-SPECIFIC OVERRIDES
+   -------------------------------------------------------------------------- */
+
+/* Navigation Buttons */
+#navbuttons input[type="submit"] {
+    @extend .nhsuk-button--small;
 }
 
-.btn-outline-secondary:not(:disabled):not(.disabled):active,
-.btn-outline-secondary:not(:disabled):not(.disabled).active,
-.show > .btn-outline-secondary.dropdown-toggle {
-  color: #212b32 !important;
-  background-color: #fff !important; // or transparent
-  border: 2px solid #212b32 !important;
-  box-shadow: inset 0 0 0 2px #212b32 !important;
-  outline: 4px solid #ffeb3b !important;
-  outline-offset: 0 !important;
-  text-decoration: none !important;
+/* Search Input Group Buttons */
+.input-group-append .btn-primary.search-icon {
+    box-shadow: none !important; 
+    border: 1px solid transparent !important;
+    border-radius: 0 0.25rem 0.25rem 0 !important;
+    width: 2.75rem !important; 
+    padding: 0 7px !important;
+    margin: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    flex-shrink: 0 !important;
+    
+    &:hover {
+        background-color: core.nhsuk-shade(core.nhsuk-colour("green"), 20%) !important;
+        color: core.nhsuk-colour("white") !important;
+        box-shadow: none !important;
+    }
+
+    &:focus {
+        background-color: core.nhsuk-colour("yellow") !important;
+        color: core.nhsuk-colour("black") !important;
+        box-shadow: 0 4px 0 core.nhsuk-colour("black") !important;
+        outline: 3px solid transparent !important;
+    }
 }
 
-/* Apply NHSUK Frontend secondary button styles to Bulk enable button on course management page */
-/* Target both the 'Bulk Enable' button and the 'Edit Restrictions' link */
-/* --- 1. DEFAULT STATE --- */
-
+/* Bulk Enable & Edit Restrictions (Course Management) */
 button.bulkEnable.btn,
 .editavailability a.btn-sm {
     @extend .nhsuk-button--secondary !optional;
     
     background-color: #ffffff !important;
     color: #005eb8 !important;
-    
-    /* THE FRAME: 2px all around prevents the 'left shift' */
     border: 2px solid #005eb8 !important;
-    
-    /* THE DEPTH: 4px Blue shadow */
-    /* Note: We use 0 2px offset to account for the 2px border, making it 4px total */
     box-shadow: 0 2px 0 0 #005eb8 !important;
-    
     display: inline-flex !important;
     align-items: center;
     padding: 10px 16px !important;
@@ -123,43 +160,59 @@ button.bulkEnable.btn,
     border-radius: 4px !important;
     position: relative;
     top: 0;
-    transition: none !important; /* NHS buttons are instant, no sliding */
+    transition: none !important; 
+
+    &:focus {
+        background-color: #ffeb3b !important;    
+        color: #212b32 !important;
+        border-color: transparent !important;    
+        box-shadow: 0 4px 0 0 #212b32, 0 0 0 0px #ffeb3b !important;        
+        outline: none !important;    
+        top: 0 !important;
+    } 
+
+    &:active {
+        top: 2px !important; 
+        box-shadow: 0 0 0 0 transparent !important;
+        border: 2px solid #005eb8 !important;
+    }
+
+    i.icon {
+        margin: 0 !important;
+        
+        &:first-child { margin-right: 8px !important; }
+        &:last-child { margin-left: 8px !important; }
+    }
 }
 
-/* --- 2. FOCUS STATE (Yellow Background + Black Shadow) --- */
-/* This remains active AFTER the click, just like the NHS site */
-
-button.bulkEnable.btn:focus, 
-.editavailability a.btn-sm:focus {
-    background-color: #ffeb3b !important;    
-    color: #212b32 !important;
-    border-color: transparent !important;    
-    box-shadow: 0 4px 0 0 #212b32, 0 0 0 0px #ffeb3b !important;        
-    outline: none !important;    
-    top: 0 !important;
-} 
-
-/* --- 3. ACTIVE STATE (The 'Pressed' Feel) --- */
-button.bulkEnable.btn:active,
-.editavailability a.btn-sm:active {
-    /* Physically drop the button */
-    top: 2px !important; 
+/* Profile Header Buttons (Message, Add to Contacts) */
+#message-user-button,
+#toggle-contact-button {
+    background-color: transparent !important;
+    color: #005eb8 !important; 
+    border: none !important;
+    font-weight: normal !important;
+    box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
     
-    /* Kill the shadow so it looks like it hit the floor */
-    box-shadow: 0 0 0 0 transparent !important;
-    
-    /* Keep the border so it doesn't lose shape */
-    border: 2px solid #005eb8 !important;
-}
+    i.icon {
+        color: #005eb8 !important;
+    }
 
-/* --- 4. ICON SPACING (Corrected) --- */
-.editavailability a.btn-sm i.icon,
-button.bulkEnable.btn i.icon {
-    margin: 0 !important;
-}
-.editavailability a.btn-sm i.icon:first-child {
-    margin-right: 8px !important;
-}
-button.bulkEnable.btn i.icon:last-child {
-    margin-left: 8px !important;
+    &:hover, 
+    &:active {
+        background-color: #d9e7f4 !important; 
+        color: #005eb8 !important;
+        box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
+    }
+
+    &:focus {
+        background-color: core.nhsuk-colour("yellow") !important;
+        color: core.nhsuk-colour("black") !important;
+        box-shadow: 0 4px 0 core.nhsuk-colour("black") !important;
+        outline: 3px solid transparent !important;
+        
+        i.icon {
+            color: core.nhsuk-colour("black") !important;
+        }
+    }
 }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -99,6 +99,67 @@
 }
 
 /* Apply NHSUK Frontend secondary button styles to Bulk enable button on course management page */
-button.bulkEnable {
-  @extend .nhsuk-button--secondary;
+/* Target both the 'Bulk Enable' button and the 'Edit Restrictions' link */
+/* --- 1. DEFAULT STATE --- */
+
+button.bulkEnable.btn,
+.editavailability a.btn-sm {
+    @extend .nhsuk-button--secondary !optional;
+    
+    background-color: #ffffff !important;
+    color: #005eb8 !important;
+    
+    /* THE FRAME: 2px all around prevents the 'left shift' */
+    border: 2px solid #005eb8 !important;
+    
+    /* THE DEPTH: 4px Blue shadow */
+    /* Note: We use 0 2px offset to account for the 2px border, making it 4px total */
+    box-shadow: 0 2px 0 0 #005eb8 !important;
+    
+    display: inline-flex !important;
+    align-items: center;
+    padding: 10px 16px !important;
+    font-weight: 600 !important;
+    border-radius: 4px !important;
+    position: relative;
+    top: 0;
+    transition: none !important; /* NHS buttons are instant, no sliding */
+}
+
+/* --- 2. FOCUS STATE (Yellow Background + Black Shadow) --- */
+/* This remains active AFTER the click, just like the NHS site */
+
+button.bulkEnable.btn:focus, 
+.editavailability a.btn-sm:focus {
+    background-color: #ffeb3b !important;    
+    color: #212b32 !important;
+    border-color: transparent !important;    
+    box-shadow: 0 4px 0 0 #212b32, 0 0 0 0px #ffeb3b !important;        
+    outline: none !important;    
+    top: 0 !important;
+} 
+
+/* --- 3. ACTIVE STATE (The 'Pressed' Feel) --- */
+button.bulkEnable.btn:active,
+.editavailability a.btn-sm:active {
+    /* Physically drop the button */
+    top: 2px !important; 
+    
+    /* Kill the shadow so it looks like it hit the floor */
+    box-shadow: 0 0 0 0 transparent !important;
+    
+    /* Keep the border so it doesn't lose shape */
+    border: 2px solid #005eb8 !important;
+}
+
+/* --- 4. ICON SPACING (Corrected) --- */
+.editavailability a.btn-sm i.icon,
+button.bulkEnable.btn i.icon {
+    margin: 0 !important;
+}
+.editavailability a.btn-sm i.icon:first-child {
+    margin-right: 8px !important;
+}
+button.bulkEnable.btn i.icon:last-child {
+    margin-left: 8px !important;
 }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -82,29 +82,45 @@
 .btn-secondary,
 .btn-outline-secondary,
 .btn-outline-primary { 
-    background-color: transparent !important;
+    background-color: #ffffff !important; 
     color: #005eb8 !important;
-    box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
-    border: none !important;
     font-weight: normal !important;
 
-    &.dropdown-toggle {
-        box-shadow: none !important;
-    }
+    border: 2px solid #005eb8 !important;
+    border-bottom-color: transparent !important;
+    box-shadow: 0 4px 0 0 #005eb8 !important; 
 
     &:hover, 
     &:active, 
     &.active {
         background-color: #d9e7f4 !important; 
         color: #005eb8 !important;
-        box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important;
+        border: 2px solid #005eb8 !important;
+        border-bottom-color: transparent !important;
+        box-shadow: 0 4px 0 0 #005eb8 !important;
     }
 
     &:focus {
         background-color: core.nhsuk-colour("yellow") !important;
         color: core.nhsuk-colour("black") !important;
+        border: 2px solid transparent !important; 
         box-shadow: 0 4px 0 core.nhsuk-colour("black") !important;
         outline: 3px solid transparent !important;
+    }
+
+    /* FIX FOR DROPDOWNS (e.g., Course Overview Filters) */
+    &.dropdown-toggle {
+        box-shadow: none !important; /* Keep shadows off layout-sensitive dropdowns */
+        border-bottom-color: #005eb8 !important; /* Restore the physical bottom line */
+        
+        /* Ensure the bottom line stays closed even when hovered or clicked open */
+        &:hover,
+        &:active,
+        &.active,
+        &.show {
+            box-shadow: none !important;
+            border-bottom-color: #005eb8 !important;
+        }
     }
 }
 
@@ -151,8 +167,12 @@ button.bulkEnable.btn,
     
     background-color: #ffffff !important;
     color: #005eb8 !important;
+    
+    /* Updated to the new transparent border trick */
     border: 2px solid #005eb8 !important;
-    box-shadow: 0 2px 0 0 #005eb8 !important;
+    border-bottom-color: transparent !important;
+    box-shadow: 0 4px 0 0 #005eb8 !important; /* Changed to 4px */
+    
     display: inline-flex !important;
     align-items: center;
     padding: 10px 16px !important;
@@ -165,7 +185,7 @@ button.bulkEnable.btn,
     &:focus {
         background-color: #ffeb3b !important;    
         color: #212b32 !important;
-        border-color: transparent !important;    
+        border: 2px solid transparent !important; /* Fixed for high-contrast safety */   
         box-shadow: 0 4px 0 0 #212b32, 0 0 0 0px #ffeb3b !important;        
         outline: none !important;    
         top: 0 !important;
@@ -188,11 +208,14 @@ button.bulkEnable.btn,
 /* Profile Header Buttons (Message, Add to Contacts) */
 #message-user-button,
 #toggle-contact-button {
-    background-color: transparent !important;
+    /* Updated to match the global secondary buttons */
+    background-color: #ffffff !important; 
     color: #005eb8 !important; 
-    border: none !important;
     font-weight: normal !important;
-    box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
+    
+    border: 2px solid #005eb8 !important;
+    border-bottom-color: transparent !important;
+    box-shadow: 0 4px 0 0 #005eb8 !important;
     
     i.icon {
         color: #005eb8 !important;
@@ -202,12 +225,15 @@ button.bulkEnable.btn,
     &:active {
         background-color: #d9e7f4 !important; 
         color: #005eb8 !important;
-        box-shadow: inset 0 0 0 2px #005eb8, 0 2px 0 0 #005eb8 !important; 
+        border: 2px solid #005eb8 !important;
+        border-bottom-color: transparent !important;
+        box-shadow: 0 4px 0 0 #005eb8 !important; 
     }
 
     &:focus {
         background-color: core.nhsuk-colour("yellow") !important;
         color: core.nhsuk-colour("black") !important;
+        border: 2px solid transparent !important;
         box-shadow: 0 4px 0 core.nhsuk-colour("black") !important;
         outline: 3px solid transparent !important;
         

--- a/templates/core_course/completion_manual.mustache
+++ b/templates/core_course/completion_manual.mustache
@@ -28,7 +28,7 @@
 }}
 {{#istrackeduser}}
     {{#overallcomplete}}
-        <button class="nhsuk-button nhsuk-button--small text-nowrap" data-action="toggle-manual-completion" data-toggletype="manual:undo" data-cmid="{{cmid}}" data-activityname="{{activityname}}" data-withavailability="{{withavailability}}" {{!
+        <button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small text-nowrap" data-action="toggle-manual-completion" data-toggletype="manual:undo" data-cmid="{{cmid}}" data-activityname="{{activityname}}" data-withavailability="{{withavailability}}" {{!
         }}{{#accessibledescription}}{{!
             }}title="{{.}}" {{!
             }}aria-label="{{.}}" {{!
@@ -41,7 +41,7 @@
         </button>
     {{/overallcomplete}}
     {{#overallincomplete}}
-        <button class="nhsuk-button nhsuk-button--small text-nowrap" data-action="toggle-manual-completion" data-toggletype="manual:mark-done" data-cmid="{{cmid}}" data-activityname="{{activityname}}" data-withavailability="{{withavailability}}" {{!
+        <button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small text-nowrap" data-action="toggle-manual-completion" data-toggletype="manual:mark-done" data-cmid="{{cmid}}" data-activityname="{{activityname}}" data-withavailability="{{withavailability}}" {{!
         }}{{#accessibledescription}}{{!
             }}title="{{.}}" {{!
             }}aria-label="{{.}}" {{!
@@ -55,7 +55,7 @@
     {{/overallincomplete}}
 {{/istrackeduser}}
 {{^istrackeduser}}
-    <button class="nhsuk-button nhsuk-button--small text-nowrap" disabled>
+    <button class="nhsuk-button nhsuk-button--secondary nhsuk-button--small text-nowrap" disabled>
         {{#str}} completion_manual:markdone, core_course {{/str}}
     </button>
 {{/istrackeduser}}


### PR DESCRIPTION
[TD-7010](https://hee-tis.atlassian.net/browse/TD-7010)
[TD-7183](https://hee-tis.atlassian.net/browse/TD-7183)

This started as just dealing with a styling issue of the Bulk actions button but then ended up dealing with the Message button (user profile) too. As part of this work I updated the primary and secondary button styling to be more in line with the NHS primary and secondary buttons as the Moodle primary button was blue.

I will be sure to request thorough testing of this one due to the multiple occurrence of buttons within the Moodle theme

 Bulk actions button
<img width="553" height="530" alt="image" src="https://github.com/user-attachments/assets/4c9d4ed1-78ef-4488-a943-acae3aaf0537" />



Message button
<img width="839" height="221" alt="image" src="https://github.com/user-attachments/assets/b10df7e0-aa11-4346-b79f-f11c24828f21" />


Primary and secondary buttons
<img width="575" height="298" alt="image" src="https://github.com/user-attachments/assets/1ccb4c1b-9aff-4f2f-beac-ef40af81e2ab" />







[TD-7010]: https://hee-tis.atlassian.net/browse/TD-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TD-7183]: https://hee-tis.atlassian.net/browse/TD-7183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ