### PR TITLE
Implement sticky lhs drawer plus one theme id fix

### DIFF
--- a/amd/src/header.js
+++ b/amd/src/header.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-console, max-len */
+define([], function() {
+    return {
+        init: function() {
+            const header = document.querySelector('.nhsuk-header') || document.querySelector('header');
+
+            if (header) {
+                const headerObserver = new ResizeObserver(entries => {
+                    for (let entry of entries) {
+                        const height = entry.borderBoxSize?.[0]?.blockSize || entry.contentRect.height;
+                        const calculatedHeight = `${Math.round(height)}px`;
+
+                        // Set the CSS variable
+                        document.documentElement.style.setProperty('--header-height', calculatedHeight);
+
+                        // Log to DevTools console
+                        console.log('[Dynamic Header Height Sync] Updated --header-height to:', calculatedHeight); // eslint-disable-line no-console
+                    }
+                });
+
+                headerObserver.observe(header);
+            } else {
+                console.warn('[Header Height Sync] Could not find header element on this page.'); // eslint-disable-line no-console
+            }
+        }
+    };
+});

--- a/javascript/nhsuk-init-module.js
+++ b/javascript/nhsuk-init-module.js
@@ -15,4 +15,50 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (e) {
         console.error("Failed to run NHS initAll():", e);
     }
+
+    // --------------------------------------------------------------------------
+    // Disable Moodle Course Index ScrollSpy
+    // --------------------------------------------------------------------------
+    const drawerContainer = document.querySelector('#nhs-courseindex-sidebar');
+    
+    if (drawerContainer) {
+        console.log("Moodle Course Index ScrollSpy detected. Disabling auto-scroll behavior...");
+        // 1. Intercept scrollIntoView calls on ALL child elements inside the course index
+        const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+        Element.prototype.scrollIntoView = function(...args) {
+            // If Moodle tries to auto-scroll any element INSIDE the LHS drawer, block it!
+            if (drawerContainer.contains(this)) {
+                console.log("BLOCKED Moodle ScrollSpy scrollIntoView on:", this);
+                return; 
+            }
+            // Otherwise, allow standard scrollIntoView behavior for the rest of the page
+            return originalScrollIntoView.apply(this, args);
+        };
+
+        // 2. Prevent Moodle JS from focusing active links and triggering native browser auto-scroll
+        drawerContainer.addEventListener('focusin', (e) => {
+            // Prevents programmatic focus during scrolling from shifting the inner drawer scrollbar
+            if (document.activeElement && drawerContainer.contains(document.activeElement)) {
+                // If focus was triggered programmatically (not via keyboard/tab key), stop scroll jumping
+                if (!e.detail) { 
+                    e.stopPropagation();
+                }
+            }
+        }, true);
+
+        // 3. (Optional) Prevent ScrollSpy from auto-expanding accordions on scroll
+        drawerContainer.addEventListener('show.bs.collapse', (e) => {
+            // Only block synthetic JS calls; allow real user clicks (!e.isTrusted)
+            if (!e.isTrusted) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        }, true);
+
+        console.log("Moodle Course Index ScrollSpy successfully disabled via Prototype Interception.");
+    }
+
+
+
 });

--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -1,6 +1,10 @@
 // Base styles for the NHSE theme
 // These are foundational styles that are not resets, but apply globally
 
+html {
+  background-color: #fff !important;
+}
+
 body {
   height: auto;
   background-color: core.$nhsuk-form-element-background-color;

--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -169,7 +169,7 @@ select.form-control:focus,
 // Course Index Drawer Focus (Sections, Subsections & Activities)
 // ---------------------------------------------------------
 
-// 1. SECTION & SUBSECTION TITLES (The working version)
+// 1. Section & Subsection Titles
 // Targets the title block directly. The :not(:has(ul :focus-within)) prevents 
 // the title from highlighting when a user tabs into a nested child activity.
 #nhs-courseindex-sidebar [role="treeitem"] {
@@ -186,7 +186,7 @@ select.form-control:focus,
     position: relative !important;
     z-index: 10 !important;
 
-    // Maintain dark text/icon contrast on yellow focus (No '&' here!)
+    // Maintain dark text/icon contrast on yellow focus
     a, span, i, .courseindex-link, .courseindex-chevron {
       color: #212b32 !important;
       background-color: transparent !important;
@@ -196,7 +196,7 @@ select.form-control:focus,
   }
 }
 
-// 2. LEAF ACTIVITIES (The working version)
+// 2. Leaf Activities
 // Targets items that do not contain a <ul> list, preventing wrappers from catching focus.
 #nhs-courseindex-sidebar .courseindex-item[role="treeitem"]:not(:has(ul)) {
   
@@ -215,4 +215,3 @@ select.form-control:focus,
     }
   }
 }
-

--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -65,40 +65,6 @@ a:not([class]):focus,
   box-shadow: none !important;
 }
 
-// Apply focus styling exclusively for keyboard navigation
-[role="treeitem"]:focus-visible:not(:hover) > .nhsuk-focus-target,
-[role="treeitem"]:focus-visible:not(:hover) > .courseindex-section > .nhsuk-focus-target {
-  background-color: #ffeb3b !important;
-  color: #212b32 !important;
-
-  a, span, i, .courseindex-link {
-    color: #212b32 !important;
-    background-color: transparent !important;
-  }
-}
-
-[role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section-title,
-[role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section > .courseindex-section-title {
-  background-color: #ffeb3b !important;
-  color: #212b32 !important;
-  box-shadow: 0 -2px #ffeb3b, 0 4px #212b32 !important;
-
-  a, span, i, .courseindex-link {
-    color: #212b32 !important;
-    background-color: transparent !important;
-  }
-}
-
-// Individual activity/page link focus
-.courseindex-item[role="treeitem"]:not(:has(.nhsuk-focus-target)):focus {
-  background-color: #ffeb3b !important;
-  color: #212b32 !important;
-  
-  .courseindex-link, span, i {
-    color: #212b32 !important;
-  }
-}
-
 // Target non-active links when a parent is focused
 // Note: Omit !important on color to allow active state overrides
 #course-index [role="treeitem"]:focus .courseindex-item:not(.is-current-page):not(.pageitem) .courseindex-link:not(:focus) {
@@ -146,8 +112,9 @@ a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
   }
 }
 
+// Neutralize Bootstrap blue focus ring
 .nav-link:focus {
-  box-shadow: none !important; // Neutralize Bootstrap blue focus ring
+  box-shadow: none !important; 
 }
 
 // Non-shifting NHS visual focus for navigation links
@@ -198,26 +165,61 @@ select.form-control:focus,
   outline-offset: 0 !important;
 }
 
-// Sidebar: ID prefix used to increase specificity over Moodle core styles
-#nhs-courseindex-sidebar .courseindex-item {
-  &:focus,
+// ---------------------------------------------------------
+// Course Index Drawer Focus (Sections, Subsections & Activities)
+// ---------------------------------------------------------
+
+// 1. SECTION & SUBSECTION TITLES (The working version)
+// Targets the title block directly. The :not(:has(ul :focus-within)) prevents 
+// the title from highlighting when a user tabs into a nested child activity.
+#nhs-courseindex-sidebar [role="treeitem"] {
+  
+  &:focus-visible > .courseindex-section-title,
+  &:focus-visible > .courseindex-section > .courseindex-section-title,
+  &:focus-visible > .nhsuk-focus-target,
+  &:focus-within:not(:has(ul :focus-within)) > .courseindex-section-title,
+  &:focus-within:not(:has(ul :focus-within)) > .courseindex-section > .courseindex-section-title,
+  &:focus-within:not(:has(ul :focus-within)) > .nhsuk-focus-target {
+    
+    background-color: #ffeb3b !important;
+    box-shadow: 0 -2px #ffeb3b, 0 4px #212b32 !important;
+    position: relative !important;
+    z-index: 10 !important;
+
+    // Maintain dark text/icon contrast on yellow focus (No '&' here!)
+    a, span, i, .courseindex-link, .courseindex-chevron {
+      color: #212b32 !important;
+      background-color: transparent !important;
+      outline: none !important;
+      box-shadow: none !important;
+    }
+  }
+}
+
+// 2. LEAF ACTIVITIES (The working version)
+// Targets items that do not contain a <ul> list, preventing wrappers from catching focus.
+#nhs-courseindex-sidebar .courseindex-item[role="treeitem"]:not(:has(ul)) {
+  
+  &:focus-visible,
   &:focus-within {
     background-color: #ffeb3b !important;
     box-shadow: 0 -2px #ffeb3b, 0 4px #212b32 !important;
     position: relative !important;
-    z-index: 10 !important; // Prevents adjacent list items from hiding the bottom shadow
-  }
+    z-index: 10 !important;
 
-  // Maintain dark text/icon contrast on yellow focus
-  &:focus .courseindex-link,
-  &:focus-within .courseindex-link,
-  &:focus .courseindex-chevron,
-  &:focus-within .courseindex-chevron,
-  &:focus i,
-  &:focus-within i {
-    color: #212b32 !important;
-    outline: none !important;
-    box-shadow: none !important;
-    background-color: transparent !important;
+    .courseindex-link, span, i, .icon {
+      color: #212b32 !important;
+      background-color: transparent !important;
+      outline: none !important;
+      box-shadow: none !important;
+    }
   }
+}
+
+// 3. THE SURGICAL SUBSECTION FIX
+// This specifically kills the text-width yellow highlight you saw on "New subsection"
+// when you focused on "Test URL 1" inside it.
+#nhs-courseindex-sidebar .courseindex-item:focus-within a.courseindex-link:not(:focus) {
+    background-color: transparent !important;
+    box-shadow: none !important;
 }

--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -1,13 +1,6 @@
 // Global focus styles for interactive elements
-// Applies to links, buttons, and form controls site-wide
-
 a {
-  &.btn {
-    &:focus {
-      @include core.nhsuk-focused-text;
-    }
-  }  
-
+  &.btn,
   &.nav-link {
     &:focus {
       @include core.nhsuk-focused-text;
@@ -15,27 +8,18 @@ a {
   }
 }
 
-button {
-  &.btn {
-    &:focus {
-      @include core.nhsuk-focused-text;
-    }
-  }
+button.btn:focus {
+  @include core.nhsuk-focused-text;
 }
 
-input {
-  &.custom-control-input {
-    &:focus {
-      outline: core.$nhsuk-focus-width solid core.$nhsuk-focus-colour; // Applies the yellow outline
-      outline-offset: 0;
-      box-shadow: 0 0 0 core.$nhsuk-focus-width core.$nhsuk-focus-colour; // Applies the yellow box shadow
-      border-color: core.$nhsuk-focus-text-colour; // Applies the thick black border effect
-    }
-  }
+input.custom-control-input:focus {
+  outline: core.$nhsuk-focus-width solid core.$nhsuk-focus-colour;
+  outline-offset: 0;
+  box-shadow: 0 0 0 core.$nhsuk-focus-width core.$nhsuk-focus-colour;
+  border-color: core.$nhsuk-focus-text-colour;
 }
 
-
-// override boost theme focus styles with NHSUK focus styles
+// Override Boost theme defaults with NHS.UK styles
 .aalink.focus,
 a.focus.autolink,
 .aalink:focus,
@@ -44,28 +28,25 @@ a.autolink:focus,
 .arrow_link:focus,
 a:not([class]).focus,
 a:not([class]):focus,
-.activityinstance>a.focus,
-.activityinstance>a:focus {
-    background-color: core.nhsuk-colour("yellow");
-    box-shadow: 0 -2px core.nhsuk-colour("yellow"), 0 3px core.nhsuk-colour("black");
-    outline: 4px solid transparent;
-    text-decoration: none;
+.activityinstance > a.focus,
+.activityinstance > a:focus {
+  background-color: core.nhsuk-colour("yellow");
+  box-shadow: 0 -2px core.nhsuk-colour("yellow"), 0 3px core.nhsuk-colour("black");
+  outline: 4px solid transparent;
+  text-decoration: none;
 }
 
 .btn.btn-icon:focus {
-    background-color: core.nhsuk-colour("yellow");
+  background-color: core.nhsuk-colour("yellow");
 }
 
-
-/* Removing style focus and adding nhsuk focus for left hand side menu button */
+// Left-hand menu toggle button overrides
 .drawer-toggles .drawer-toggler .btn:focus {
   @include core.nhsuk-focused-button;
 }
 
-/* Prevent boost CSS affecting the toggle button position */
 #page .drawer-toggles .drawer-toggler {
-  top: unset;
-  /* prevent static CSS from interfering */
+  top: unset; // Prevents Boost static CSS from altering position
 }
 
 .drawerheader .aabtn.text-reset.d-flex.align-items-center.py-1.h-100.d-md-none,
@@ -73,71 +54,69 @@ a:not([class]):focus,
   display: none !important;
 }
 
-/* 1. THE GLOBAL RESET */
-/* Removes Moodle's default focus rings to make way for our NHS yellow */
+// ---------------------------------------------------------
+// Course Index Focus States
+// ---------------------------------------------------------
+
+// Remove Moodle's default focus rings
 .courseindex [role="treeitem"]:focus,
 .courseindex [role="treeitem"]:not([aria-expanded="true"]):focus {
-    outline: 0 !important;
-    box-shadow: none !important;
+  outline: 0 !important;
+  box-shadow: none !important;
 }
 
-
-/* 2. THE SECTION HIGHLIGHT */
-/* When a section title is focused (via Tab or Click) */
-/* Apply red/yellow focus ONLY on keyboard navigation, excluding mouse-activated focus */
+// Apply focus styling exclusively for keyboard navigation
 [role="treeitem"]:focus-visible:not(:hover) > .nhsuk-focus-target,
 [role="treeitem"]:focus-visible:not(:hover) > .courseindex-section > .nhsuk-focus-target {
-    background-color: #ffeb3b !important; /* or red !important */
-    color: #212b32 !important;
+  background-color: #ffeb3b !important;
+  color: #212b32 !important;
 
-    a, span, i, .courseindex-link {
-        color: #212b32 !important;
-        background-color: transparent !important;
-    }
+  a, span, i, .courseindex-link {
+    color: #212b32 !important;
+    background-color: transparent !important;
+  }
 }
+
 [role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section-title,
 [role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section > .courseindex-section-title {
-    background-color: #ffeb3b !important;
-    color: #212b32 !important;
+  background-color: #ffeb3b !important;
+  color: #212b32 !important;
+  box-shadow: 0 -2px #ffeb3b, 0 4px #212b32 !important;
 
-    a, span, i, .courseindex-link {
-        color: #212b32 !important;
-        background-color: transparent !important;
-    }
+  a, span, i, .courseindex-link {
+    color: #212b32 !important;
+    background-color: transparent !important;
+  }
 }
 
-/* 3. THE ACTIVITY HIGHLIGHT */
-/* When an individual activity/page link is focused */
+// Individual activity/page link focus
 .courseindex-item[role="treeitem"]:not(:has(.nhsuk-focus-target)):focus {
-    background-color: #ffeb3b !important;
+  background-color: #ffeb3b !important;
+  color: #212b32 !important;
+  
+  .courseindex-link, span, i {
     color: #212b32 !important;
-    .courseindex-link, span, i {
-        color: #212b32 !important;
-    }
+  }
 }
 
-/* 4. THE SHIELD (Surgical Version) */
-/* This rule targets non-active links when a parent is focused. */
-/* CRITICAL: No !important on color here. This allows Rule 5 to override it. */
+// Target non-active links when a parent is focused
+// Note: Omit !important on color to allow active state overrides
 #course-index [role="treeitem"]:focus .courseindex-item:not(.is-current-page):not(.pageitem) .courseindex-link:not(:focus) {
-    color: red; 
-    background-color: transparent;
+  color: red; 
+  background-color: transparent;
 }
 
-
-/* 6. THE SUBSECTION / SECTION ENFORCER */
-/* Applies the same 'Active' logic if the section itself is the current target */
+// Active section styling
 .is-current-section > .courseindex-item {
-    background-color: #005eb8 !important;
+  background-color: #005eb8 !important;
+  color: #ffffff !important;
+  
+  a, span, i {
     color: #ffffff !important;
-    
-    a, span, i {
-        color: #ffffff !important;
-    }
+  }
 }
 
-/* 7. THE FINAL PROTECTION */
-/* Ensures all icons and badges inside any blue active element stay white */
+// Ensure icon and badge contrast inside active elements
 .is-current-page i, 
 .is-current-page span,
 .is-current-section i,
@@ -145,90 +124,69 @@ a:not([class]):focus,
 .pageitem i,
 .pageitem span,
 .pageitem .courseindex-link {
-    color: #212b32 !important;
+  color: #212b32 !important;
 }
 
-/* skip link focus colour */
+// ---------------------------------------------------------
+// Navigation & Form Controls
+// ---------------------------------------------------------
+
 a.sr-only.sr-only-focusable[href="#maincontent"]:focus {
   @include core.nhsuk-focused-button;
 }
 
-
-
-/* focus colour on activity completion buttons */
-.activity-item .activity-completion button.btn:focus,
-.activity-item .activity-completion button.btn.focus,
-.activity-item .activity-completion button.btn-success:focus,
-.activity-item .activity-completion button.btn:focus,
-.activity-item .activity-completion a[role=button].btn:focus,
-.activity-item .activity-completion a[role=button].btn.focus {
-  @include core.nhsuk-focused-button;
+// Activity completion buttons
+.activity-item .activity-completion {
+  button.btn:focus,
+  button.btn.focus,
+  button.btn-success:focus,
+  a[role=button].btn:focus,
+  a[role=button].btn.focus {
+    @include core.nhsuk-focused-button;
+  }
 }
 
-
-/* Neutralizes the generic Bootstrap blue focus ring */
 .nav-link:focus {
-  box-shadow: none !important;
-  /* You may need to add outline: none !important; here if the blue ring persists */
+  box-shadow: none !important; // Neutralize Bootstrap blue focus ring
 }
 
-
-/* Applies the final, non-shifting NHS visual focus/active style to navigation links */
+// Non-shifting NHS visual focus for navigation links
 a.nav-link:focus,
 a.nav-link:active {
-  /* --- 1. OVERRIDE THE CONFLICTING BORDER RESET --- */
   border-width: 0 !important;
   border-bottom-width: 4px !important;
-  /* Forces the required 4px bottom border */
-
-  /* FIX FOR SHIFTING: Maintain 4px space at the top using a transparent border */
-  border-top: 4px solid transparent !important;
-
-  /* --- 2. APPLY NHS FOCUS VISUALS --- */
+  border-top: 4px solid transparent !important; // Transparent top border prevents layout shift
   background-color: core.nhsuk-colour("yellow") !important;
   border-bottom-color: core.nhsuk-colour("black") !important;
-  /* Sets the color of the 4px bottom border */
   border-style: solid !important;
-
   color: core.nhsuk-colour("black") !important;
-  /* --- 3. CLEANUP --- */
   box-shadow: none !important;
   outline: none !important;
   text-decoration: none !important;
 }
 
-
-// Prevent global style applying for dropdown buttons preventing the yellow and black appearance
-
+// Prevent global styles from overriding dropdown appearance
 .dropdown-item,
 .dropdown-item:visited {
   box-shadow: none !important;
 }
 
-
 .btn.dropdown-toggle,
 .btn-outline-secondary.dropdown-toggle {
-  box-shadow: none !important; // No shadow by default
+  box-shadow: none !important; 
 }
 
 .btn.dropdown-toggle:focus,
-.btn-outline-secondary.dropdown-toggle:focus {
+.btn-outline-secondary.dropdown-toggle:focus,
+select.form-control:focus,
+.custom-select:focus {
   border: 2px solid #212b32 !important;
   box-shadow: inset 0 0 0 2px #212b32 !important;
   outline: 4px solid #ffeb3b !important;
   outline-offset: 0 !important;
   background-color: transparent !important;
   text-decoration: none !important;
-}
-
-/* Apply the same NHS focus style to standard Select menus */
-select.form-control:focus,
-.custom-select:focus {
-    border: 2px solid #212b32 !important;
-    box-shadow: inset 0 0 0 2px #212b32 !important;
-    outline: 4px solid #ffeb3b !important;
-    outline-offset: 0 !important;
-    color: #212b32 !important;
+  color: #212b32 !important;
 }
 
 .simplesearchform .form-control:focus {
@@ -238,4 +196,28 @@ select.form-control:focus,
   box-shadow: inset 0 0 0 2px #212b32 !important;
   outline: 4px solid #ffeb3b !important;
   outline-offset: 0 !important;
+}
+
+// Sidebar: ID prefix used to increase specificity over Moodle core styles
+#nhs-courseindex-sidebar .courseindex-item {
+  &:focus,
+  &:focus-within {
+    background-color: #ffeb3b !important;
+    box-shadow: 0 -2px #ffeb3b, 0 4px #212b32 !important;
+    position: relative !important;
+    z-index: 10 !important; // Prevents adjacent list items from hiding the bottom shadow
+  }
+
+  // Maintain dark text/icon contrast on yellow focus
+  &:focus .courseindex-link,
+  &:focus-within .courseindex-link,
+  &:focus .courseindex-chevron,
+  &:focus-within .courseindex-chevron,
+  &:focus i,
+  &:focus-within i {
+    color: #212b32 !important;
+    outline: none !important;
+    box-shadow: none !important;
+    background-color: transparent !important;
+  }
 }

--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -6,13 +6,7 @@ a {
     &:focus {
       @include core.nhsuk-focused-text;
     }
-  }
-
-  &.btn {
-    &:focus {
-      @include core.nhsuk-focused-text;
-    }
-  }
+  }  
 
   &.nav-link {
     &:focus {
@@ -90,18 +84,19 @@ a:not([class]):focus,
 
 /* 2. THE SECTION HIGHLIGHT */
 /* When a section title is focused (via Tab or Click) */
-[role="treeitem"]:focus > .nhsuk-focus-target,
-[role="treeitem"]:focus > .courseindex-section > .nhsuk-focus-target {
-    background-color: #ffeb3b !important;
+/* Apply red/yellow focus ONLY on keyboard navigation, excluding mouse-activated focus */
+[role="treeitem"]:focus-visible:not(:hover) > .nhsuk-focus-target,
+[role="treeitem"]:focus-visible:not(:hover) > .courseindex-section > .nhsuk-focus-target {
+    background-color: #ffeb3b !important; /* or red !important */
     color: #212b32 !important;
-    
+
     a, span, i, .courseindex-link {
         color: #212b32 !important;
         background-color: transparent !important;
     }
 }
-[role="treeitem"]:focus > .courseindex-section-title,
-[role="treeitem"]:focus > .courseindex-section > .courseindex-section-title {
+[role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section-title,
+[role="treeitem"]:focus-visible:not(:hover):not(:active) > .courseindex-section > .courseindex-section-title {
     background-color: #ffeb3b !important;
     color: #212b32 !important;
 
@@ -125,20 +120,10 @@ a:not([class]):focus,
 /* This rule targets non-active links when a parent is focused. */
 /* CRITICAL: No !important on color here. This allows Rule 5 to override it. */
 #course-index [role="treeitem"]:focus .courseindex-item:not(.is-current-page):not(.pageitem) .courseindex-link:not(:focus) {
-    color: #005eb8; 
+    color: red; 
     background-color: transparent;
 }
 
-/* 5. THE ACTIVE ENFORCER */
-/* This ensures the active page/activity is ALWAYS NHS Blue with White text. */
-/* This rule WINS because it still uses !important. */
-.is-current-page, 
-.is-current-page .courseindex-link,
-.courseindex-item.pageitem,
-.courseindex-item.pageitem .courseindex-link {
-    background-color: #005eb8 !important;
-    color: #ffffff !important;
-}
 
 /* 6. THE SUBSECTION / SECTION ENFORCER */
 /* Applies the same 'Active' logic if the section itself is the current target */
@@ -160,7 +145,7 @@ a:not([class]):focus,
 .pageitem i,
 .pageitem span,
 .pageitem .courseindex-link {
-    color: #ffffff !important;
+    color: #212b32 !important;
 }
 
 /* skip link focus colour */

--- a/scss/base/_focus.scss
+++ b/scss/base/_focus.scss
@@ -216,10 +216,3 @@ select.form-control:focus,
   }
 }
 
-// 3. THE SURGICAL SUBSECTION FIX
-// This specifically kills the text-width yellow highlight you saw on "New subsection"
-// when you focused on "Test URL 1" inside it.
-#nhs-courseindex-sidebar .courseindex-item:focus-within a.courseindex-link:not(:focus) {
-    background-color: transparent !important;
-    box-shadow: none !important;
-}

--- a/scss/components/_comments.scss
+++ b/scss/components/_comments.scss
@@ -1,0 +1,18 @@
+.comment-area {
+  padding: 10px 0 0;
+}
+
+.comment-list {
+  font-size: 1rem;
+  color: core.$nhsuk-text-color;
+
+  li {
+    background-color: core.nhsuk-colour("white");
+    margin: 0;
+    margin-bottom: 10px;
+  }
+}
+
+.comment-ctrl {
+  font-size: 1rem;
+}

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -97,42 +97,126 @@
   .drawer-left,
   .drawer-right {
     top: 135px;
-    height: calc(100vh - 124px)
+    height: auto !important;
   }
 }
 
 /* Ensure when active section is highlighed the focus style is still accessible */
 
 .courseindex {
-    .completioninfo {
-        display: inline-flex;
-        align-items: center; // Vertically centers the icon container
-        align-self: center;   // Centers the container within the menu item flex row
-        
-        .icon {
-            font-size: 0.6rem;    // Adjust size if needed
-            margin-top: 0.5rem;   // Manual "nudge" if it still looks slightly high
-            vertical-align: middle; 
-        }
-    }
-    .courseindex-item.pageitem {
-        background-color: #005eb8;
-        color: #fff;
-        scroll-margin: 6rem;
+  .completioninfo {
+    display: inline-flex;
+    align-items: center; // Vertically centers the icon container
+    align-self: center; // Centers the container within the menu item flex row
 
-        // When the active item is focused, ensure it follows NHS accessibility
-        &:focus-within,
-        &:focus {
-            background-color: transparent; // Prevents blue from peeking out
-            
-            a.courseindex-link {
-                background-color: #ffeb3b !important;
-                color: #212b32 !important; // NHS Dark Text for contrast
-                box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
-                text-decoration: none;
-            }
-        }
+    .icon {
+      font-size: 0.6rem; // Adjust size if needed
+      margin-top: 0.5rem; // Manual "nudge" if it still looks slightly high
+      vertical-align: middle;
     }
+  }
 
+  .courseindex-item.pageitem {
+    background-color: #005eb8;
+    color: #fff;
+    scroll-margin: 6rem;
+
+    // When the active item is focused, ensure it follows NHS accessibility
+    &:focus-within,
+    &:focus {
+      background-color: transparent; // Prevents blue from peeking out
+
+      a.courseindex-link {
+        background-color: #ffeb3b !important;
+        color: #212b32 !important; // NHS Dark Text for contrast
+        box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
+        text-decoration: none;
+      }
+    }
+  }
+
+
+}
+
+
+@media (min-width: 992px) {
+  /* let the page be as long as it needs to be */ 
+  body,
+  #page-wrapper {
+    overflow: visible !important;
+  }
+
+  // new encompassing container around the lhs drawer and content
+
+  .nhs-main-layout {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: flex-start !important;
+    position: relative !important;
+    flex: 1 0 auto !important;
+
+    //* Conditionally apply  only if the lhs  drawer is open */
+    body:has(#page.show-drawer-left) & {
+      width: auto;      
+    }
+  }
+
+
+  /* The drawer is hidden and takes up no space */
+  /* This is to prevent it affecting page layout */
+  .nhs-main-layout .nhs-static-drawer {
+    display: none !important;
+    visibility: hidden;    
+  }
+
+  /* Sticky lhs drawer */
+  /* Note the lhs drawer has a fixed width of 285px */
+  .nhs-main-layout .nhs-static-drawer.show {
+    display: block !important;
+    visibility: visible !important;    
+    position: sticky !important;
+    top: 0px !important;
+    min-width: 285px !important;
+    max-width: 285px !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+    transform: none !important;
+    transition: none !important;
+    background-color: #fff;
+    height: auto !important;
+
+    .drawer-header {
+      display: flex !important;
+      height: 60px; // Match your actual header height
+      min-height: 60px;
+      margin-top: 1rem;
+    }
+  }
+
+
+
+ 
+ /* Force main content container to bypass fixed-height/sticky constraints. */
+ /* This allows the content and drawer to flow naturally, ensuring the footer */
+ /* is correctly pushed by the total page height rather than being trapped */
+ /* by a viewport-locked container. */
+ 
+  body.pagelayout-course .nhs-main-layout #page,
+  body.pagelayout-incourse .nhs-main-layout #page,
+  body.pagelayout-report .nhs-main-layout #page,
+  body.pagelayout-admin .nhs-main-layout #page,
+  body.pagelayout-base .nhs-main-layout #page {
+    height: auto !important;
+    overflow: visible !important;
+    margin: 0 !important;
+    padding-left: 0 !important;
+    flex: 1 1 auto !important;
+  }
+
+  /* vertically centre the close button within the drawers header */
+  #nhs-courseindex-sidebar .drawer-header .drawertoggle {
+    display: inline-flex;
+    align-items: center;
+  }
 
 }

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -44,12 +44,27 @@
       color: #005eb8 !important;
     }
 
+    // Apply underline ONLY to the text link when the row is hovered
     &:hover {
-      text-decoration: underline !important;
+      .courseindex-link {
+        text-decoration: underline !important;
+      }
       
       &.pageitem {
         background-color: transparent; 
         color: inherit;
+      }
+    }
+
+    // Failsafe: Explicitly prevent chevrons, completion icons, and locks 
+    // from ever receiving an underline, even if hovered directly.
+    .courseindex-chevron,
+    .courseindex-locked,
+    .completioninfo {
+      text-decoration: none !important;
+      
+      &:hover {
+        text-decoration: none !important;
       }
     }
 
@@ -124,7 +139,6 @@
     }
   }
 }
-
 
 // ==========================================================================
 // 3. DESKTOP LAYOUT & STICKY DRAWER (Large Screens +)

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -44,8 +44,10 @@
       color: #005eb8 !important;
     }
 
-    // Apply underline ONLY to the text link when the row is hovered
-    &:hover {
+    // Apply underline ONLY to the text link of the specific row being hovered.
+    // The :not(:has(...)) prevents parent section titles from underlining 
+    // when you hover over one of their nested child activities.
+    &:hover:not(:has(.courseindex-item:hover)) {
       .courseindex-link {
         text-decoration: underline !important;
       }
@@ -65,19 +67,6 @@
       
       &:hover {
         text-decoration: none !important;
-      }
-    }
-
-    // NHS Accessibility: Focus states (Default)
-    &:focus-within,
-    &:focus {
-      background-color: transparent; 
-
-      a.courseindex-link {
-        background-color: #ffeb3b !important;
-        color: #212b32 !important; 
-        box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
-        text-decoration: none;
       }
     }
   }
@@ -125,21 +114,7 @@
       color: #005eb8 !important;
     }
   }
-
-  // Retain accessible focus styles ONLY when a user actively clicks or tabs
-  .courseindex-item {
-    &:focus-visible,
-    &:focus-within:has(:focus-visible) {
-      a.courseindex-link {
-        background-color: #ffeb3b !important; 
-        color: #212b32 !important;            
-        box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
-        text-decoration: none;
-      }
-    }
-  }
 }
-
 // ==========================================================================
 // 3. DESKTOP LAYOUT & STICKY DRAWER (Large Screens +)
 // ==========================================================================

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -29,7 +29,6 @@
   padding: 1.25rem !important;
 }
 
-
 // ==========================================================================
 // 2. COURSE INDEX (LHS MENU) STYLES
 // ==========================================================================
@@ -59,7 +58,7 @@
     }
 
     // Failsafe: Explicitly prevent chevrons, completion icons, and locks 
-    // from ever receiving an underline, even if hovered directly.
+    // from receiving an underline, even if hovered directly.
     .courseindex-chevron,
     .courseindex-locked,
     .completioninfo {
@@ -115,13 +114,14 @@
     }
   }
 }
+
 // ==========================================================================
 // 3. DESKTOP LAYOUT & STICKY DRAWER (Large Screens +)
 // ==========================================================================
 
 @media (min-width: 992px) {
   
-  // Let the page be as long as it needs to be 
+  // Allow unrestricted page height
   body,
   #page-wrapper {
     overflow: visible !important;

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -1,8 +1,6 @@
-/* ==========================================================================
-// DRAWER STYLES
-// Moodle includes a left hand side drawer for the course index
-// and a right hand side drawer for displaying blocks
-// ========================================================================== */
+// ==========================================================================
+// 1. GLOBAL DRAWER & CONTENT STYLES
+// ==========================================================================
 
 .drawer {
   // Global drawer text size
@@ -10,103 +8,146 @@
     font-size: 15px;
   }
 
-  /*  RHS Block Drawer: Padding for list items inside blocks (e.g., HTML blocks, Overview) */
-  .card-text {
-    li {
-      padding: .25rem .5rem;
-    }
+  // RHS Block Drawer: Padding for list items inside blocks
+  .card-text li {
+    padding: 0.25rem 0.5rem;
   }
 }
 
-/* LHS and RHS drawercontent default heading styles */
+// LHS and RHS drawer content default heading styles
 .drawercontent {
-  h1,
-  h2,
-  h3 {
+  h1, h2, h3 {
     margin-bottom: 0;
-    padding: .25rem .5rem;
+    padding: 0.25rem 0.5rem;
     line-height: 1.5;
   }
 }
-/* Add padding to cards on my overview page - note this does not affect the lhs or rhs drawers */
-.drawers {
-  .block_myoverview>.card-body {
-    padding: 1.25rem !important;
-  }
+
+// Add padding to cards on 'my overview' page 
+// Note: This does not affect the LHS or RHS drawers
+.drawers .block_myoverview > .card-body {
+  padding: 1.25rem !important;
 }
 
-@media (min-width: 992px) {
 
-  .drawer-left,
-  .drawer-right {    
-    height: auto !important;
-  }
-
-  /* Dynamically calculate the RHS drawer top using the current header height */
-  .drawer-right {
-    top: var(--header-height, 135px) !important;    
-  }
-}
-
-/* Ensure when active section is highlighed the focus style is still accessible */
+// ==========================================================================
+// 2. COURSE INDEX (LHS MENU) STYLES
+// ==========================================================================
 
 .courseindex {
-  .completioninfo {
-    display: inline-flex;
-    align-items: center; // Vertically centers the icon container
-    align-self: center; // Centers the container within the menu item flex row
+  // --- Global Item Styles ---
+  .courseindex-item {
+    border-radius: 0 !important;
+    border: 0 !important;
 
-    .icon {
-      font-size: 0.6rem; // Adjust size if needed
-      margin-top: 0.5rem; // Manual "nudge" if it still looks slightly high
-      vertical-align: middle;
+    .courseindex-link {
+      color: #005eb8 !important;
     }
-  }
-  
-  .courseindex-item .courseindex-link{
-    color: #005eb8 !important;
 
     &:hover {
       text-decoration: underline !important;
+      
+      &.pageitem {
+        background-color: transparent; 
+        color: inherit;
+      }
     }
-  }
-  .courseindex-item.pageitem {
-    /* background-color: #005eb8; */
-    /* color: #fff; */
-    background: linear-gradient(to right, #005eb8 0.4rem, transparent 0);
-    color: #005eb8 !important;
-    border-radius: 0 !important;
-    border:0 !important;
-    font-weight: bold;
-    scroll-margin: 6rem;
 
-    // When the active item is focused, ensure it follows NHS accessibility
+    // NHS Accessibility: Focus states (Default)
     &:focus-within,
     &:focus {
-      background-color: transparent; // Prevents blue from peeking out
+      background-color: transparent; 
 
       a.courseindex-link {
         background-color: #ffeb3b !important;
-        color: #212b32 !important; // NHS Dark Text for contrast
+        color: #212b32 !important; 
         box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
         text-decoration: none;
       }
     }
   }
 
+  // --- Active / Highlighted Page Item ---
+  .courseindex-item.pageitem {
+    background: linear-gradient(to right, #005eb8 0.4rem, transparent 0);
+    color: #005eb8 !important;
+    font-weight: bold;
+    scroll-margin: 6rem;
+  }
 
+  // --- Icons & Completion Status ---
+  .completioninfo {
+    display: inline-flex;
+    align-items: center; 
+    align-self: center; 
+
+    .icon {
+      font-size: 0.6rem; 
+      margin-top: 0.5rem; 
+      vertical-align: middle;
+    }
+  }
+
+  // Prevent status icon on LHS menu pushing text across
+  .icon {
+    margin-right: 0 !important;
+  }
+}
+
+// --- Course View Specific Overrides (Disable scroll highlighting) ---
+.path-course-view .courseindex {
+  // Target active classes to suppress JS scroll highlighting
+  .courseindex-item.pageitem,
+  .courseindex-item.is-active,
+  .courseindex-item.active {
+    background: transparent !important;
+    background-color: transparent !important;
+    color: #005eb8 !important;
+    font-weight: normal !important;
+
+    a.courseindex-link {
+      background-color: transparent !important;
+      color: #005eb8 !important;
+    }
+  }
+
+  // Retain accessible focus styles ONLY when a user actively clicks or tabs
+  .courseindex-item {
+    &:focus-visible,
+    &:focus-within:has(:focus-visible) {
+      a.courseindex-link {
+        background-color: #ffeb3b !important; 
+        color: #212b32 !important;            
+        box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
+        text-decoration: none;
+      }
+    }
+  }
 }
 
 
+// ==========================================================================
+// 3. DESKTOP LAYOUT & STICKY DRAWER (Large Screens +)
+// ==========================================================================
+
 @media (min-width: 992px) {
-  /* let the page be as long as it needs to be */ 
+  
+  // Let the page be as long as it needs to be 
   body,
   #page-wrapper {
     overflow: visible !important;
   }
 
-  // new encompassing container around the lhs drawer and content
+  // Dynamically calculate the RHS drawer top using the current header height
+  .drawer-left,
+  .drawer-right {    
+    height: auto !important;
+  }
+  .drawer-right {
+    top: var(--header-height, 135px) !important;    
+  }
 
+  // --- NHS Main Layout Wrapper ---
   .nhs-main-layout {
     display: flex !important;
     flex-direction: row !important;
@@ -114,117 +155,63 @@
     position: relative !important;
     flex: 1 0 auto !important;
 
-    //* Conditionally apply  only if the lhs  drawer is open */
+    // Conditionally apply only if the LHS drawer is open 
     body:has(#page.show-drawer-left) & {
       width: auto;      
     }
-  }
 
-
-  /* The drawer is hidden and takes up no space */
-  /* This is to prevent it affecting page layout */
-  .nhs-main-layout .nhs-static-drawer {
-    display: none !important;
-    visibility: hidden;    
-  }
-
-  /* Sticky lhs drawer */
-  /* Note the lhs drawer has a fixed width of 285px */
-  .nhs-main-layout .nhs-static-drawer.show {
-    display: block !important;
-    visibility: visible !important;    
-    position: sticky !important;
-    top: 0px !important;
-    z-index: 1 !important; /* Lowers sticky layer below dropdown menus */
-    min-width: 285px !important;
-    max-width: 285px !important;
-    overflow-y: auto !important;
-    overflow-x: hidden !important;
-    transform: none !important;
-    transition: none !important;
-    background-color: #f8f9fa;
-    height: auto !important;
-
-    .drawer-header {
-      display: flex !important;
-      height: 60px; // Match your actual header height
-      min-height: 60px;
-      margin-top: 1rem;
-    }
-  }
-
-
-
- 
- /* Force main content container to bypass fixed-height/sticky constraints. */
- /* This allows the content and drawer to flow naturally, ensuring the footer */
- /* is correctly pushed by the total page height rather than being trapped */
- /* by a viewport-locked container. */
- 
-  body.pagelayout-course .nhs-main-layout #page,
-  body.pagelayout-incourse .nhs-main-layout #page,
-  body.pagelayout-report .nhs-main-layout #page,
-  body.pagelayout-admin .nhs-main-layout #page,
-  body.pagelayout-base .nhs-main-layout #page {
-    height: auto !important;
-    overflow: visible !important;
-    margin: 0 !important;
-    padding-left: 0 !important;
-    flex: 1 1 auto !important;
-  }
-
-  /* vertically centre the close button within the drawers header */
-  #nhs-courseindex-sidebar .drawer-header .drawertoggle {
-    display: inline-flex;
-    align-items: center;
-  }
-
-}
-
-/* ==========================================================================
-// COURSE INDEX - DISABLE SCROLL HIGHLIGHTING
-// ========================================================================== */
-.path-course-view {
-  .courseindex {
-    /* Target .pageitem (and fallback active classes) to suppress scroll highlighting */
-    .courseindex-item.pageitem,
-    .courseindex-item.is-active,
-    .courseindex-item.active {
-      background: transparent !important;
-      background-color: transparent !important;
-      color: #005eb8 !important;
-      font-weight: normal !important;
-
-      a.courseindex-link {
-        background-color: transparent !important;
-        color: #005eb8 !important;
-      }
+    // Default hidden state to prevent affecting page layout
+    .nhs-static-drawer {
+      display: none !important;
+      visibility: hidden;    
     }
 
-    /* Retain accessible focus styles ONLY when a user actively clicks or tabs */
-    .courseindex-item {
-      border:0 !important;
-      /* :focus-visible ensures JS scrollspy .focus() calls are ignored */
-      &:focus-visible,
-      &:focus-within:has(:focus-visible) {
-        /* background-color: transparent !important; */ 
+    // Sticky LHS drawer (Active State)
+    .nhs-static-drawer.show {
+      display: block !important;
+      visibility: visible !important;    
+      position: sticky !important;
+      top: 0px !important;
+      z-index: 1 !important; // Lowers sticky layer below dropdown menus
+      min-width: 285px !important;
+      max-width: 285px !important;
+      overflow-y: auto !important;
+      overflow-x: hidden !important;
+      transform: none !important;
+      transition: none !important;
+      background-color: #f8f9fa;
+      height: auto !important;
 
-        a.courseindex-link {
-          background-color: #ffeb3b !important; // NHS Yellow
-          color: #212b32 !important;            // NHS Dark Text
-          box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
-          text-decoration: none;
+      .drawer-header {
+        display: flex !important;
+        height: 60px; // Match actual header height
+        min-height: 60px;
+        margin-top: 1rem;
+        
+        // Vertically centre the close button
+        .drawertoggle {
+          display: inline-flex;
+          align-items: center;
         }
       }
     }
   }
+  
+  // Force main content container to bypass fixed-height/sticky constraints.
+  // This allows the content and drawer to flow naturally, ensuring the footer 
+  // is correctly pushed by the total page height rather than being trapped 
+  // by a viewport-locked container.
+  body.pagelayout-course,
+  body.pagelayout-incourse,
+  body.pagelayout-report,
+  body.pagelayout-admin,
+  body.pagelayout-base {
+    .nhs-main-layout #page {
+      height: auto !important;
+      overflow: visible !important;
+      margin: 0 !important;
+      padding-left: 0 !important;
+      flex: 1 1 auto !important;
+    }
+  }
 }
-
-
-
-/* prevent status icon on LHS menu pushing text across */
-.drawercontent .courseindex .icon {
-  margin-right: 0 !important;
-}
-
-

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -135,6 +135,7 @@
     visibility: visible !important;    
     position: sticky !important;
     top: 0px !important;
+    z-index: 1 !important; /* Lowers sticky layer below dropdown menus */
     min-width: 285px !important;
     max-width: 285px !important;
     overflow-y: auto !important;
@@ -225,4 +226,5 @@
 .drawercontent .courseindex .icon {
   margin-right: 0 !important;
 }
+
 

--- a/scss/components/_drawer.scss
+++ b/scss/components/_drawer.scss
@@ -1,12 +1,16 @@
 /* ==========================================================================
 // DRAWER STYLES
+// Moodle includes a left hand side drawer for the course index
+// and a right hand side drawer for displaying blocks
 // ========================================================================== */
 
 .drawer {
+  // Global drawer text size
   ul {
     font-size: 15px;
   }
 
+  /*  RHS Block Drawer: Padding for list items inside blocks (e.g., HTML blocks, Overview) */
   .card-text {
     li {
       padding: .25rem .5rem;
@@ -14,9 +18,8 @@
   }
 }
 
+/* LHS and RHS drawercontent default heading styles */
 .drawercontent {
-  height: calc(100% - 124px);
-
   h1,
   h2,
   h3 {
@@ -25,79 +28,23 @@
     line-height: 1.5;
   }
 }
-
+/* Add padding to cards on my overview page - note this does not affect the lhs or rhs drawers */
 .drawers {
   .block_myoverview>.card-body {
     padding: 1.25rem !important;
   }
 }
 
-.comment-area {
-  padding: 10px 0 0;
-}
-
-.comment-list {
-  font-size: 1rem;
-  color: core.$nhsuk-text-color;
-
-  li {
-    background-color: core.nhsuk-colour("white");
-    margin: 0;
-    margin-bottom: 10px;
-  }
-}
-
-.comment-ctrl {
-  font-size: 1rem;
-}
-
-
-.dropdown-menu {
-  min-width: 20rem;
-}
-
-[data-region=right-hand-drawer].drawer {
-  top: 84px;
-  height: calc(100% - 149px)
-}
-
-@media (min-width: 640px) {
-  [data-region=right-hand-drawer].drawer {
-    top: 92px;
-  }
-}
-
-@media (min-width: 768px) {
-  .d-md-none {
-    display: block !important;
-  }
-
-  [data-region=right-hand-drawer].drawer {
-    top: 92px;
-  }
-
-  body.limitedwidth {
-    #page.drawers {
-      .footer-popover {
-        max-width: none;
-      }
-    }
-  }
-}
-
 @media (min-width: 992px) {
-  .d-md-none {
-    display: none !important;
-  }
-
-  [data-region=right-hand-drawer].drawer {
-    top: 140px;
-  }
 
   .drawer-left,
-  .drawer-right {
-    top: 135px;
+  .drawer-right {    
     height: auto !important;
+  }
+
+  /* Dynamically calculate the RHS drawer top using the current header height */
+  .drawer-right {
+    top: var(--header-height, 135px) !important;    
   }
 }
 
@@ -115,10 +62,22 @@
       vertical-align: middle;
     }
   }
+  
+  .courseindex-item .courseindex-link{
+    color: #005eb8 !important;
 
+    &:hover {
+      text-decoration: underline !important;
+    }
+  }
   .courseindex-item.pageitem {
-    background-color: #005eb8;
-    color: #fff;
+    /* background-color: #005eb8; */
+    /* color: #fff; */
+    background: linear-gradient(to right, #005eb8 0.4rem, transparent 0);
+    color: #005eb8 !important;
+    border-radius: 0 !important;
+    border:0 !important;
+    font-weight: bold;
     scroll-margin: 6rem;
 
     // When the active item is focused, ensure it follows NHS accessibility
@@ -182,7 +141,7 @@
     overflow-x: hidden !important;
     transform: none !important;
     transition: none !important;
-    background-color: #fff;
+    background-color: #f8f9fa;
     height: auto !important;
 
     .drawer-header {
@@ -220,3 +179,50 @@
   }
 
 }
+
+/* ==========================================================================
+// COURSE INDEX - DISABLE SCROLL HIGHLIGHTING
+// ========================================================================== */
+.path-course-view {
+  .courseindex {
+    /* Target .pageitem (and fallback active classes) to suppress scroll highlighting */
+    .courseindex-item.pageitem,
+    .courseindex-item.is-active,
+    .courseindex-item.active {
+      background: transparent !important;
+      background-color: transparent !important;
+      color: #005eb8 !important;
+      font-weight: normal !important;
+
+      a.courseindex-link {
+        background-color: transparent !important;
+        color: #005eb8 !important;
+      }
+    }
+
+    /* Retain accessible focus styles ONLY when a user actively clicks or tabs */
+    .courseindex-item {
+      border:0 !important;
+      /* :focus-visible ensures JS scrollspy .focus() calls are ignored */
+      &:focus-visible,
+      &:focus-within:has(:focus-visible) {
+        /* background-color: transparent !important; */ 
+
+        a.courseindex-link {
+          background-color: #ffeb3b !important; // NHS Yellow
+          color: #212b32 !important;            // NHS Dark Text
+          box-shadow: 0 -2px #ffeb3b, 0 4px #212b32;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+}
+
+
+
+/* prevent status icon on LHS menu pushing text across */
+.drawercontent .courseindex .icon {
+  margin-right: 0 !important;
+}
+

--- a/scss/components/_grade-report.scss
+++ b/scss/components/_grade-report.scss
@@ -7,8 +7,8 @@
     justify-items: stretch;             /* addition to go with above Firefox fixEnsures small tables stretch full-width in Chrome/Edge */
 }
 
-#page-grade-report-grader-index #user-grades {
-    width: max-content !important;
+#page-grade-report-grader-index #user-grades {    
+    width: 100% !important;
     min-width: 100%;
 }
 

--- a/scss/layout/_layout.scss
+++ b/scss/layout/_layout.scss
@@ -40,8 +40,21 @@ body.lockscroll {
     }
 
     .main-inner {
-      padding: 1.5rem 1.5rem;
+      padding: 1.5rem;
       width: 100%;
+
+      @media (min-width: 1200px) {
+
+        /* When lhs drawer is closed set a minimum width to ensure the content doesn't sit in a central column */
+        body:not(:has(#page.show-drawer-left)) & {
+          min-width: 1200px;
+        }
+
+        /* When lhs drawer is open give the page a minimum width to content doesnt sit in a central column if the content width is smaller */
+        /* Ensures the total width (285+915) is 1200px */
+        body:has(#page.show-drawer-left) & {
+          min-width: 915px;        }
+        }
     }
   }
 
@@ -54,7 +67,8 @@ body.lockscroll {
 /* Prevents footer sitting half way up the page when there is little content */
 
 #page-wrapper {
-  min-height: 100vh;
+  height: auto !important;
+  min-height: 100vh !important;
   display: flex;
   flex-direction: column;
 }
@@ -64,8 +78,6 @@ body.lockscroll {
   display: flex;
   flex-direction: column;
 }
-
-
 
 /**
  * Max width except reportbuilder
@@ -243,20 +255,35 @@ body.pagelayout-report #page.drawers .main-inner {
   border-radius: 0;
 }
 
-/* Course page content area padding to allow room for left hand side menu toggle */
-body.limitedwidth.pagelayout-course #page-wrapper #page .main-inner,
-body.pagelayout-incourse #page-wrapper #page .main-inner,
-body.pagelayout-report #page-wrapper #page .main-inner {
-  padding-left: 3.5rem;
-  padding-right: 3.5rem;
+/* Allow space for the draw toggle buttons */
+/* 1. At wide widths (1200px+), the central container has room, 
+      so we keep padding minimal to maximize content space. */
+@media (min-width: 1200px) {
+
+  /* Base State: Drawer CLOSED  */
+  body.pagelayout-course #page-wrapper #page .main-inner,
+  body.pagelayout-incourse #page-wrapper #page .main-inner,
+  body.pagelayout-report #page-wrapper #page .main-inner {
+    padding-left: 2rem !important;
+    padding-right: 1rem !important;
+  }
+
+  /* Override State: Drawer is OPEN (5rem) */
+  /* This provides breathing room between the lhs drawer and the content  */
+  #page.show-drawer-left .main-inner {
+    padding-left: 5rem !important;
+  }
 }
 
-/* Course page content area padding to allow room for left hand side menu toggle */
-body.limitedwidth.pagelayout-course #page-wrapper #page .main-inner,
-body.pagelayout-incourse #page-wrapper #page .main-inner,
-body.pagelayout-report #page-wrapper #page .main-inner {
-  padding-left: 3.5rem;
-  padding-right: 3.5rem;
+/* When the screen narrows (below 1200px), the 2.5rem left padding 
+      provides space for the lhs drawer toggle button. */
+@media (max-width: 1199px) {
+  body.pagelayout-course #page-wrapper #page .main-inner,
+  body.pagelayout-incourse #page-wrapper #page .main-inner,
+  body.pagelayout-report #page-wrapper #page .main-inner {
+    padding-left: 2.5rem !important;
+    padding-right: 1rem !important;
+  }
 }
 
 /* remove the max-width restriction and allow the breadcrumb and title */

--- a/scss/nhsetel.scss
+++ b/scss/nhsetel.scss
@@ -65,4 +65,5 @@ $btn-secondary-border: core.nhsuk-colour("dark-blue");
 @import "components/icons";
 @import "components/multitopic";
 @import "components/big-blue-button";
+@import "components/comments";
 

--- a/settings.php
+++ b/settings.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($ADMIN->fulltree) {
-    $settings = new theme_boost_admin_settingspage_tabs('themesettingnhse', get_string('configtitle', 'theme_nhsetel'));
+    $settings = new theme_boost_admin_settingspage_tabs('themesettingnhsetel', get_string('configtitle', 'theme_nhsetel'));
     $page = new admin_settingpage('theme_nhsetel_general', get_string('generalsettings', 'theme_nhsetel'));
 
      // Theme customisable property: Add the .NET Application Base URL setting to the 'General' tab ---

--- a/templates/core_courseformat/local/courseindex/section.mustache
+++ b/templates/core_courseformat/local/courseindex/section.mustache
@@ -79,13 +79,13 @@
             aria-controls="courseindexcollapse{{number}}"
             tabindex="-1"
         >
-            <span class="collapsed-icon icon-no-margin me-1"
+            <span class="collapsed-icon icon-no-margin"
                 title="{{#str}} expand, core {{/str}}">
                 <span class="dir-rtl-hide">{{#pix}} t/collapsedchevron, core {{/pix}}</span>
                 <span class="dir-ltr-hide">{{#pix}} t/collapsedchevron_rtl, core {{/pix}}</span>
                 <span class="sr-only">{{#str}} expand, core {{/str}}</span>
             </span>
-            <span class="expanded-icon icon-no-margin me-1"
+            <span class="expanded-icon icon-no-margin"
                 title="{{#str}} collapse, core {{/str}}">
                 {{#pix}} t/expandedchevron, core {{/pix}}
                 <span class="sr-only">{{#str}} collapse, core {{/str}}</span>

--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -67,23 +67,37 @@
         {{> theme_nhsetel/header }}
     {{/ output.get_global_header_data }}
 
-    {{#courseindex}}
-        {{< theme_boost/drawer }}
-            {{$id}}theme_boost-drawers-courseindex{{/id}}
-            {{$drawerheadercontent}}
-                {{> theme_nhsetel/courseindexdrawercontrols}}
-            {{/drawerheadercontent}}
-            {{$drawerclasses}}drawer drawer-left {{#courseindexopen}}show{{/courseindexopen}}{{/drawerclasses}}
-            {{$drawercontent}}
+    {{! NEW WRAPPER: Encapsulates the columns below the header }}
+    <div class="nhs-main-layout nhsuk-width-container">
+
+{{#courseindex}}
+        <div id="nhs-courseindex-sidebar" 
+     class="show drawer drawer-left nhs-static-drawer {{#courseindexopen}}show{{/courseindexopen}}" 
+     data-region="fixed-drawer" 
+     data-preference="drawer-open-index" 
+     data-state="show-drawer-left" 
+     tabindex="-1">       
+            <div class="drawer-header py-3">         
+                <button class="btn drawertoggle icon-no-margin" 
+                    data-toggler="drawers" 
+                    data-action="closedrawer" 
+                    data-target="nhs-courseindex-sidebar" 
+                    title="Close course index"
+                    aria-label="Close course index">
+                    <i class="icon fa fa-xmark fa-fw"></i>
+                </button>
+            </div>
+
+           
+            
+            <div class="drawercontent p-3">
                 {{{output.page_heading}}}
                 {{{courseindex}}}
-            {{/drawercontent}}
-            {{$drawerpreferencename}}drawer-open-index{{/drawerpreferencename}}
-            {{$drawerstate}}show-drawer-left{{/drawerstate}}
-            {{$tooltipplacement}}right{{/tooltipplacement}}
-            {{$closebuttontext}}{{#str}}closecourseindex, core{{/str}}{{/closebuttontext}}
-        {{/ theme_boost/drawer }}
+            </div>                 
+        </div>
     {{/courseindex}}
+
+
 
     {{#hasblocks}}
         {{< theme_boost/drawer }}
@@ -105,7 +119,7 @@
     {{/hasblocks}}
 
     <div id="page" class="nhsuk-width-container-fluid drawers {{#courseindexopen}}show-drawer-left{{/courseindexopen}} {{#blockdraweropen}}show-drawer-right{{/blockdraweropen}} drag-container"
-         data-region="mainpage" data-usertour="scroller">
+         data-region="mainpage" >
         <div id="topofscroll" class="main-inner nhsuk-u-padding-bottom-4">
             <div class="drawer-toggles d-flex">
                 {{#courseindex}}
@@ -114,7 +128,7 @@
                             class="btn icon-no-margin"
                             data-toggler="drawers"
                             data-action="toggle"
-                            data-target="theme_boost-drawers-courseindex"
+                            data-target="nhs-courseindex-sidebar"
                             data-toggle="tooltip"
                             data-placement="right"
                             title="{{#str}}opendrawerindex, core{{/str}}"
@@ -176,8 +190,10 @@
                 </div>
             </div>
         </div>
+    </div> <!-- end of div id="page"-->    
     </div>
-    <!-- end of div id="page"-->
+    {{! END OF WRAPPER .nhs-main-layout }}
+    
 
     {{# output.get_footer_data }}
         {{> theme_nhsetel/footer }}
@@ -190,7 +206,7 @@
 </html>
 {{#js}}
 M.util.js_pending('theme_boost/loader');
-require(['theme_boost/loader', 'theme_boost/drawer'], function(Loader, Drawer) {
+require(['theme_boost/loader', 'theme_boost/drawer'], function(Loader, Drawer) {    
     Drawer.init();
     M.util.js_complete('theme_boost/loader');
 });

--- a/templates/drawers.mustache
+++ b/templates/drawers.mustache
@@ -206,8 +206,10 @@
 </html>
 {{#js}}
 M.util.js_pending('theme_boost/loader');
-require(['theme_boost/loader', 'theme_boost/drawer'], function(Loader, Drawer) {    
+require(['theme_boost/loader', 'theme_boost/drawer', 'theme_nhsetel/header'], function(Loader, Drawer, Header) {    
     Drawer.init();
+    Header.init(); // Initializes your header observer with console logging
+    
     M.util.js_complete('theme_boost/loader');
 });
 {{/js}}


### PR DESCRIPTION
### JIRA link
[TD-6909](https://hee-tis.atlassian.net/browse/TD-6909)

### Description
This is a significant update to the display of the lhs drawer. Previously an update allowed the header to scroll off the top of the screen but the lhs drawer was set to a fixed vertical position based on a fixed header height. This update changes the lhs drawer so it will move up with the header as the page scrolls but will stop when the lhs drawer gets to the top (sticky).

I have had to add a containing div around the lhs drawer the content area (div with id #page) to achieve what I wanted and even then it has been a battle.

In addition to his lhs drawer change, I have thrown in a theme id change - just something I missed on the recent theme id update. I had missed one setting and this was preventing being able to open the theme settings.

Here is a quick summary of the changed files

settings.php: Update to fix issue with the theme settings not appearing. I missed a setting when changing the theme unique id

_base.scss: Change of the main background colour to white to match the Learning Hub more closely

_grade-report.scss: Fix for report display issue

drawers.mustache: I have added a container div to encapsulate the lhs drawer and the content. This is to enable me to set up the sticky lhs drawer.

_layout.scss:

	SCSS to ensure the lhs drawer and content area don't display in a narrow central position.
	SCSS to get the footer to display at the bottom of the screen if the content is short.
	SCSS to provide breathing space between the lhs drawer and the content area
	SCSS to leave some space for the lhs drawer toggle button 
	
_drawer.scss

	SCSS to set drawer height

### Screenshots
<img width="2407" height="1407" alt="image" src="https://github.com/user-attachments/assets/fb663dfa-cb64-4a85-b379-bd0d3060022b" />

<img width="2470" height="1517" alt="image" src="https://github.com/user-attachments/assets/318b7b36-45f3-4693-8637-92fe27fe3eab" />

<img width="2471" height="1364" alt="image" src="https://github.com/user-attachments/assets/c6541544-4f39-42ab-bb29-4b578dfade3e" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-6909]: https://hee-tis.atlassian.net/browse/TD-6909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ