### PR TITLE
restore self-enrolment key field in enrolment layout

### DIFF
--- a/scss/components/_enrolement.scss
+++ b/scss/components/_enrolement.scss
@@ -12,8 +12,7 @@
   max-width: 100%;
 }
 
-#page-enrol-index #id_selfheader .icons-collapse-expand,
-#page-enrol-index #id_selfheadercontainer {
+#page-enrol-index #id_selfheader .icons-collapse-expand {
   display: none;
 }
 


### PR DESCRIPTION
### JIRA link
[TD-7656](https://hee-tis.atlassian.net/browse/TD-7656)

### Description
Bob Smith reported that the form field was not appearing allowing a user to enter an enrolment key. Switching themes revealed it appeared on other themes hence some CSS in our theme was hiding it. I have removed one of the css elements to make this appear again. 

### Screenshots
<img width="1413" height="883" alt="image" src="https://github.com/user-attachments/assets/91b8b2c5-f69f-4782-b27b-75c77d40f13d" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes
- [ ] Manually tested my work with and without JavaScript
- [X] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-7656]: https://hee-tis.atlassian.net/browse/TD-7656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ